### PR TITLE
Add mocked configs for display settings

### DIFF
--- a/webapp/components/user_settings/user_settings_display.jsx
+++ b/webapp/components/user_settings/user_settings_display.jsx
@@ -18,8 +18,8 @@ const Preferences = Constants.Preferences;
 
 import {FormattedMessage} from 'react-intl';
 
-const EnableFontManagement = false;
 const EnableThemeManagement = false;
+const EnableFontManagement = false;
 const EnableDisplayNameManagement = false;
 
 function getDisplayStateFromStores() {
@@ -203,6 +203,7 @@ export default class UserSettingsDisplay extends React.Component {
 
             return (
                 <div>
+                    <div className='divider-dark'/>
                     <SettingItemMax
                         title={
                             <FormattedMessage
@@ -215,7 +216,6 @@ export default class UserSettingsDisplay extends React.Component {
                         server_error={this.state.serverError}
                         updateSection={handleUpdateCollapseSection}
                     />
-                    <div className='divider-dark'/>
                 </div>
             );
         }
@@ -243,6 +243,7 @@ export default class UserSettingsDisplay extends React.Component {
 
         return (
             <div>
+                <div className='divider-dark'/>
                 <SettingItemMin
                     title={
                         <FormattedMessage
@@ -253,7 +254,6 @@ export default class UserSettingsDisplay extends React.Component {
                     describe={describe}
                     updateSection={handleUpdateCollapseSection}
                 />
-                <div className='divider-dark'/>
             </div>
         );
     }
@@ -266,6 +266,10 @@ export default class UserSettingsDisplay extends React.Component {
         let fontSection;
         let languagesSection;
         let messageDisplaySection;
+
+        const themeSectionClass = EnableThemeManagement ? 'first' : '';
+        const fontSectionClass = (!EnableThemeManagement && EnableFontManagement) ? 'first' : '';
+        const clockSelectionClass = (EnableThemeManagement || EnableFontManagement) ? '' : 'first';
 
         const collapseSection = this.createCollapseSection();
 
@@ -326,6 +330,7 @@ export default class UserSettingsDisplay extends React.Component {
 
             clockSection = (
                 <div>
+                    <div className={`divider-dark ${clockSelectionClass}`}/>
                     <SettingItemMax
                         title={
                             <FormattedMessage
@@ -338,7 +343,6 @@ export default class UserSettingsDisplay extends React.Component {
                         server_error={serverError}
                         updateSection={handleUpdateClockSection}
                     />
-                    <div className='divider-dark'/>
                 </div>
             );
         } else {
@@ -365,6 +369,7 @@ export default class UserSettingsDisplay extends React.Component {
 
             clockSection = (
                 <div>
+                    <div className={`divider-dark ${clockSelectionClass}`}/>
                     <SettingItemMin
                         title={
                             <FormattedMessage
@@ -375,7 +380,6 @@ export default class UserSettingsDisplay extends React.Component {
                         describe={describe}
                         updateSection={handleUpdateClockSection}
                     />
-                    <div className='divider-dark'/>
                 </div>
             );
         }
@@ -459,6 +463,7 @@ export default class UserSettingsDisplay extends React.Component {
             if (EnableDisplayNameManagement) {
                 nameFormatSection = (
                     <div>
+                        <div className='divider-dark'/>
                         <SettingItemMax
                             title={
                                 <FormattedMessage
@@ -474,7 +479,6 @@ export default class UserSettingsDisplay extends React.Component {
                                 e.preventDefault();
                             }}
                         />
-                        <div className='divider-dark'/>
                     </div>
                 );
             }
@@ -506,6 +510,7 @@ export default class UserSettingsDisplay extends React.Component {
             if (EnableDisplayNameManagement) {
                 nameFormatSection = (
                     <div>
+                        <div className='divider-dark'/>
                         <SettingItemMin
                             title={
                                 <FormattedMessage
@@ -518,7 +523,6 @@ export default class UserSettingsDisplay extends React.Component {
                                 this.props.updateSection('name_format');
                             }}
                         />
-                        <div className='divider-dark'/>
                     </div>
                 );
             }
@@ -590,6 +594,7 @@ export default class UserSettingsDisplay extends React.Component {
 
             messageDisplaySection = (
                 <div>
+                    <div className='divider-dark'/>
                     <SettingItemMax
                         title={
                             <FormattedMessage
@@ -605,7 +610,6 @@ export default class UserSettingsDisplay extends React.Component {
                             e.preventDefault();
                         }}
                     />
-                    <div className='divider-dark'/>
                 </div>
             );
         } else {
@@ -628,6 +632,7 @@ export default class UserSettingsDisplay extends React.Component {
 
             messageDisplaySection = (
                 <div>
+                    <div className='divider-dark'/>
                     <SettingItemMin
                         title={
                             <FormattedMessage
@@ -640,7 +645,6 @@ export default class UserSettingsDisplay extends React.Component {
                             this.props.updateSection(Preferences.MESSAGE_DISPLAY);
                         }}
                     />
-                    <div className='divider-dark'/>
                 </div>
             );
         }
@@ -697,6 +701,7 @@ export default class UserSettingsDisplay extends React.Component {
 
             channelDisplayModeSection = (
                 <div>
+                    <div className='divider-dark'/>
                     <SettingItemMax
                         title={
                             <FormattedMessage
@@ -712,7 +717,6 @@ export default class UserSettingsDisplay extends React.Component {
                             e.preventDefault();
                         }}
                     />
-                    <div className='divider-dark'/>
                 </div>
             );
         } else {
@@ -735,6 +739,7 @@ export default class UserSettingsDisplay extends React.Component {
 
             channelDisplayModeSection = (
                 <div>
+                    <div className='divider-dark'/>
                     <SettingItemMin
                         title={
                             <FormattedMessage
@@ -747,7 +752,6 @@ export default class UserSettingsDisplay extends React.Component {
                             this.props.updateSection(Preferences.CHANNEL_DISPLAY_MODE);
                         }}
                     />
-                    <div className='divider-dark'/>
                 </div>
             );
         }
@@ -794,6 +798,7 @@ export default class UserSettingsDisplay extends React.Component {
             if (EnableFontManagement) {
                 fontSection = (
                     <div>
+                        <div className={`divider-dark ${fontSectionClass}`}/>
                         <SettingItemMax
                             title={
                                 <FormattedMessage
@@ -809,13 +814,13 @@ export default class UserSettingsDisplay extends React.Component {
                                 e.preventDefault();
                             }}
                         />
-                        <div className='divider-dark'/>
                     </div>
                 );
             }
         } else if (EnableFontManagement) {
             fontSection = (
                 <div>
+                    <div className={`divider-dark ${fontSectionClass}`}/>
                     <SettingItemMin
                         title={
                             <FormattedMessage
@@ -828,7 +833,6 @@ export default class UserSettingsDisplay extends React.Component {
                             this.props.updateSection('font');
                         }}
                     />
-                    <div className='divider-dark'/>
                 </div>
             );
         }
@@ -840,6 +844,7 @@ export default class UserSettingsDisplay extends React.Component {
             }
             languagesSection = (
                 <div>
+                    <div className='divider-dark'/>
                     <ManageLanguages
                         user={this.props.user}
                         updateSection={(e) => {
@@ -847,7 +852,6 @@ export default class UserSettingsDisplay extends React.Component {
                             e.preventDefault();
                         }}
                     />
-                    <div className='divider-dark'/>
                 </div>
             );
         } else {
@@ -860,6 +864,7 @@ export default class UserSettingsDisplay extends React.Component {
 
             languagesSection = (
                 <div>
+                    <div className='divider-dark'/>
                     <SettingItemMin
                         title={
                             <FormattedMessage
@@ -873,7 +878,6 @@ export default class UserSettingsDisplay extends React.Component {
                             this.updateSection('languages');
                         }}
                     />
-                    <div className='divider-dark'/>
                 </div>
             );
         }
@@ -882,13 +886,13 @@ export default class UserSettingsDisplay extends React.Component {
         if (EnableThemeManagement) {
             themeSection = (
                 <div>
+                    <div className={`divider-dark ${themeSectionClass}`}/>
                     <ThemeSetting
                         selected={this.props.activeSection === 'theme'}
                         updateSection={this.updateSection}
                         setRequireConfirm={this.props.setRequireConfirm}
                         setEnforceFocus={this.props.setEnforceFocus}
                     />
-                    <div className='divider-dark'/>
                 </div>
             );
         }
@@ -936,6 +940,7 @@ export default class UserSettingsDisplay extends React.Component {
                     {messageDisplaySection}
                     {channelDisplayModeSection}
                     {languagesSection}
+                    <div className='divider-dark'/>
                 </div>
             </div>
         );

--- a/webapp/components/user_settings/user_settings_display.jsx
+++ b/webapp/components/user_settings/user_settings_display.jsx
@@ -18,6 +18,10 @@ const Preferences = Constants.Preferences;
 
 import {FormattedMessage} from 'react-intl';
 
+const EnableFontManagement = false;
+const EnableThemeManagement = false;
+const EnableDisplayNameManagement = false;
+
 function getDisplayStateFromStores() {
     return {
         militaryTime: PreferenceStore.get(Preferences.CATEGORY_DISPLAY_SETTINGS, 'use_military_time', 'false'),
@@ -198,18 +202,21 @@ export default class UserSettingsDisplay extends React.Component {
             ];
 
             return (
-                <SettingItemMax
-                    title={
-                        <FormattedMessage
-                            id='user.settings.display.collapseDisplay'
-                            defaultMessage='Link previews'
-                        />
-                    }
-                    inputs={inputs}
-                    submit={this.handleSubmit}
-                    server_error={this.state.serverError}
-                    updateSection={handleUpdateCollapseSection}
-                />
+                <div>
+                    <SettingItemMax
+                        title={
+                            <FormattedMessage
+                                id='user.settings.display.collapseDisplay'
+                                defaultMessage='Link previews'
+                            />
+                        }
+                        inputs={inputs}
+                        submit={this.handleSubmit}
+                        server_error={this.state.serverError}
+                        updateSection={handleUpdateCollapseSection}
+                    />
+                    <div className='divider-dark'/>
+                </div>
             );
         }
 
@@ -235,16 +242,19 @@ export default class UserSettingsDisplay extends React.Component {
         };
 
         return (
-            <SettingItemMin
-                title={
-                    <FormattedMessage
-                        id='user.settings.display.collapseDisplay'
-                        defaultMessage='Link previews'
-                    />
-                }
-                describe={describe}
-                updateSection={handleUpdateCollapseSection}
-            />
+            <div>
+                <SettingItemMin
+                    title={
+                        <FormattedMessage
+                            id='user.settings.display.collapseDisplay'
+                            defaultMessage='Link previews'
+                        />
+                    }
+                    describe={describe}
+                    updateSection={handleUpdateCollapseSection}
+                />
+                <div className='divider-dark'/>
+            </div>
         );
     }
 
@@ -315,18 +325,21 @@ export default class UserSettingsDisplay extends React.Component {
             ];
 
             clockSection = (
-                <SettingItemMax
-                    title={
-                        <FormattedMessage
-                            id='user.settings.display.clockDisplay'
-                            defaultMessage='Clock Display'
-                        />
-                    }
-                    inputs={inputs}
-                    submit={this.handleSubmit}
-                    server_error={serverError}
-                    updateSection={handleUpdateClockSection}
-                />
+                <div>
+                    <SettingItemMax
+                        title={
+                            <FormattedMessage
+                                id='user.settings.display.clockDisplay'
+                                defaultMessage='Clock Display'
+                            />
+                        }
+                        inputs={inputs}
+                        submit={this.handleSubmit}
+                        server_error={serverError}
+                        updateSection={handleUpdateClockSection}
+                    />
+                    <div className='divider-dark'/>
+                </div>
             );
         } else {
             let describe;
@@ -351,16 +364,19 @@ export default class UserSettingsDisplay extends React.Component {
             };
 
             clockSection = (
-                <SettingItemMin
-                    title={
-                        <FormattedMessage
-                            id='user.settings.display.clockDisplay'
-                            defaultMessage='Clock Display'
-                        />
-                    }
-                    describe={describe}
-                    updateSection={handleUpdateClockSection}
-                />
+                <div>
+                    <SettingItemMin
+                        title={
+                            <FormattedMessage
+                                id='user.settings.display.clockDisplay'
+                                defaultMessage='Clock Display'
+                            />
+                        }
+                        describe={describe}
+                        updateSection={handleUpdateClockSection}
+                    />
+                    <div className='divider-dark'/>
+                </div>
             );
         }
 
@@ -440,23 +456,28 @@ export default class UserSettingsDisplay extends React.Component {
                 </div>
             ];
 
-            nameFormatSection = (
-                <SettingItemMax
-                    title={
-                        <FormattedMessage
-                            id='user.settings.display.teammateDisplay'
-                            defaultMessage='Teammate Name Display'
+            if (EnableDisplayNameManagement) {
+                nameFormatSection = (
+                    <div>
+                        <SettingItemMax
+                            title={
+                                <FormattedMessage
+                                    id='user.settings.display.teammateDisplay'
+                                    defaultMessage='Teammate Name Display'
+                                />
+                            }
+                            inputs={inputs}
+                            submit={this.handleSubmit}
+                            server_error={serverError}
+                            updateSection={(e) => {
+                                this.updateSection('');
+                                e.preventDefault();
+                            }}
                         />
-                    }
-                    inputs={inputs}
-                    submit={this.handleSubmit}
-                    server_error={serverError}
-                    updateSection={(e) => {
-                        this.updateSection('');
-                        e.preventDefault();
-                    }}
-                />
-            );
+                        <div className='divider-dark'/>
+                    </div>
+                );
+            }
         } else {
             let describe;
             if (this.state.nameFormat === 'username') {
@@ -482,20 +503,25 @@ export default class UserSettingsDisplay extends React.Component {
                 );
             }
 
-            nameFormatSection = (
-                <SettingItemMin
-                    title={
-                        <FormattedMessage
-                            id='user.settings.display.teammateDisplay'
-                            defaultMessage='Teammate Name Display'
+            if (EnableDisplayNameManagement) {
+                nameFormatSection = (
+                    <div>
+                        <SettingItemMin
+                            title={
+                                <FormattedMessage
+                                    id='user.settings.display.teammateDisplay'
+                                    defaultMessage='Teammate Name Display'
+                                />
+                            }
+                            describe={describe}
+                            updateSection={() => {
+                                this.props.updateSection('name_format');
+                            }}
                         />
-                    }
-                    describe={describe}
-                    updateSection={() => {
-                        this.props.updateSection('name_format');
-                    }}
-                />
-            );
+                        <div className='divider-dark'/>
+                    </div>
+                );
+            }
         }
 
         if (this.props.activeSection === Preferences.MESSAGE_DISPLAY) {
@@ -563,21 +589,24 @@ export default class UserSettingsDisplay extends React.Component {
             ];
 
             messageDisplaySection = (
-                <SettingItemMax
-                    title={
-                        <FormattedMessage
-                            id='user.settings.display.messageDisplayTitle'
-                            defaultMessage='Message Display'
-                        />
-                    }
-                    inputs={inputs}
-                    submit={this.handleSubmit}
-                    server_error={serverError}
-                    updateSection={(e) => {
-                        this.updateSection('');
-                        e.preventDefault();
-                    }}
-                />
+                <div>
+                    <SettingItemMax
+                        title={
+                            <FormattedMessage
+                                id='user.settings.display.messageDisplayTitle'
+                                defaultMessage='Message Display'
+                            />
+                        }
+                        inputs={inputs}
+                        submit={this.handleSubmit}
+                        server_error={serverError}
+                        updateSection={(e) => {
+                            this.updateSection('');
+                            e.preventDefault();
+                        }}
+                    />
+                    <div className='divider-dark'/>
+                </div>
             );
         } else {
             let describe;
@@ -598,18 +627,21 @@ export default class UserSettingsDisplay extends React.Component {
             }
 
             messageDisplaySection = (
-                <SettingItemMin
-                    title={
-                        <FormattedMessage
-                            id='user.settings.display.messageDisplayTitle'
-                            defaultMessage='Message Display'
-                        />
-                    }
-                    describe={describe}
-                    updateSection={() => {
-                        this.props.updateSection(Preferences.MESSAGE_DISPLAY);
-                    }}
-                />
+                <div>
+                    <SettingItemMin
+                        title={
+                            <FormattedMessage
+                                id='user.settings.display.messageDisplayTitle'
+                                defaultMessage='Message Display'
+                            />
+                        }
+                        describe={describe}
+                        updateSection={() => {
+                            this.props.updateSection(Preferences.MESSAGE_DISPLAY);
+                        }}
+                    />
+                    <div className='divider-dark'/>
+                </div>
             );
         }
 
@@ -664,21 +696,24 @@ export default class UserSettingsDisplay extends React.Component {
             ];
 
             channelDisplayModeSection = (
-                <SettingItemMax
-                    title={
-                        <FormattedMessage
-                            id='user.settings.display.channelDisplayTitle'
-                            defaultMessage='Channel Display Mode'
-                        />
-                    }
-                    inputs={inputs}
-                    submit={this.handleSubmit}
-                    server_error={serverError}
-                    updateSection={(e) => {
-                        this.updateSection('');
-                        e.preventDefault();
-                    }}
-                />
+                <div>
+                    <SettingItemMax
+                        title={
+                            <FormattedMessage
+                                id='user.settings.display.channelDisplayTitle'
+                                defaultMessage='Channel Display Mode'
+                            />
+                        }
+                        inputs={inputs}
+                        submit={this.handleSubmit}
+                        server_error={serverError}
+                        updateSection={(e) => {
+                            this.updateSection('');
+                            e.preventDefault();
+                        }}
+                    />
+                    <div className='divider-dark'/>
+                </div>
             );
         } else {
             let describe;
@@ -699,18 +734,21 @@ export default class UserSettingsDisplay extends React.Component {
             }
 
             channelDisplayModeSection = (
-                <SettingItemMin
-                    title={
-                        <FormattedMessage
-                            id='user.settings.display.channelDisplayTitle'
-                            defaultMessage='Channel Display Mode'
-                        />
-                    }
-                    describe={describe}
-                    updateSection={() => {
-                        this.props.updateSection(Preferences.CHANNEL_DISPLAY_MODE);
-                    }}
-                />
+                <div>
+                    <SettingItemMin
+                        title={
+                            <FormattedMessage
+                                id='user.settings.display.channelDisplayTitle'
+                                defaultMessage='Channel Display Mode'
+                            />
+                        }
+                        describe={describe}
+                        updateSection={() => {
+                            this.props.updateSection(Preferences.CHANNEL_DISPLAY_MODE);
+                        }}
+                    />
+                    <div className='divider-dark'/>
+                </div>
             );
         }
 
@@ -753,37 +791,45 @@ export default class UserSettingsDisplay extends React.Component {
                 </div>
             ];
 
-            fontSection = (
-                <SettingItemMax
-                    title={
-                        <FormattedMessage
-                            id='user.settings.display.fontTitle'
-                            defaultMessage='Display Font'
+            if (EnableFontManagement) {
+                fontSection = (
+                    <div>
+                        <SettingItemMax
+                            title={
+                                <FormattedMessage
+                                    id='user.settings.display.fontTitle'
+                                    defaultMessage='Display Font'
+                                />
+                            }
+                            inputs={inputs}
+                            submit={this.handleSubmit}
+                            server_error={serverError}
+                            updateSection={(e) => {
+                                this.updateSection('');
+                                e.preventDefault();
+                            }}
                         />
-                    }
-                    inputs={inputs}
-                    submit={this.handleSubmit}
-                    server_error={serverError}
-                    updateSection={(e) => {
-                        this.updateSection('');
-                        e.preventDefault();
-                    }}
-                />
-            );
-        } else {
+                        <div className='divider-dark'/>
+                    </div>
+                );
+            }
+        } else if (EnableFontManagement) {
             fontSection = (
-                <SettingItemMin
-                    title={
-                        <FormattedMessage
-                            id='user.settings.display.fontTitle'
-                            defaultMessage='Display Font'
-                        />
-                    }
-                    describe={this.state.selectedFont}
-                    updateSection={() => {
-                        this.props.updateSection('font');
-                    }}
-                />
+                <div>
+                    <SettingItemMin
+                        title={
+                            <FormattedMessage
+                                id='user.settings.display.fontTitle'
+                                defaultMessage='Display Font'
+                            />
+                        }
+                        describe={this.state.selectedFont}
+                        updateSection={() => {
+                            this.props.updateSection('font');
+                        }}
+                    />
+                    <div className='divider-dark'/>
+                </div>
             );
         }
 
@@ -793,13 +839,16 @@ export default class UserSettingsDisplay extends React.Component {
                 this.props.user.locale = global.window.mm_config.DefaultClientLocale;
             }
             languagesSection = (
-                <ManageLanguages
-                    user={this.props.user}
-                    updateSection={(e) => {
-                        this.updateSection('');
-                        e.preventDefault();
-                    }}
-                />
+                <div>
+                    <ManageLanguages
+                        user={this.props.user}
+                        updateSection={(e) => {
+                            this.updateSection('');
+                            e.preventDefault();
+                        }}
+                    />
+                    <div className='divider-dark'/>
+                </div>
             );
         } else {
             let locale;
@@ -810,19 +859,37 @@ export default class UserSettingsDisplay extends React.Component {
             }
 
             languagesSection = (
-                <SettingItemMin
-                    title={
-                        <FormattedMessage
-                            id='user.settings.display.language'
-                            defaultMessage='Language'
-                        />
-                    }
-                    width='medium'
-                    describe={locale}
-                    updateSection={() => {
-                        this.updateSection('languages');
-                    }}
-                />
+                <div>
+                    <SettingItemMin
+                        title={
+                            <FormattedMessage
+                                id='user.settings.display.language'
+                                defaultMessage='Language'
+                            />
+                        }
+                        width='medium'
+                        describe={locale}
+                        updateSection={() => {
+                            this.updateSection('languages');
+                        }}
+                    />
+                    <div className='divider-dark'/>
+                </div>
+            );
+        }
+
+        let themeSection;
+        if (EnableThemeManagement) {
+            themeSection = (
+                <div>
+                    <ThemeSetting
+                        selected={this.props.activeSection === 'theme'}
+                        updateSection={this.updateSection}
+                        setRequireConfirm={this.props.setRequireConfirm}
+                        setEnforceFocus={this.props.setEnforceFocus}
+                    />
+                    <div className='divider-dark'/>
+                </div>
             );
         }
 
@@ -861,26 +928,13 @@ export default class UserSettingsDisplay extends React.Component {
                             defaultMessage='Display Settings'
                         />
                     </h3>
-                    <div className='divider-dark first'/>
-                    <ThemeSetting
-                        selected={this.props.activeSection === 'theme'}
-                        updateSection={this.updateSection}
-                        setRequireConfirm={this.props.setRequireConfirm}
-                        setEnforceFocus={this.props.setEnforceFocus}
-                    />
-                    <div className='divider-dark'/>
+                    {themeSection}
                     {fontSection}
-                    <div className='divider-dark'/>
                     {clockSection}
-                    <div className='divider-dark'/>
                     {nameFormatSection}
-                    <div className='divider-dark'/>
                     {collapseSection}
-                    <div className='divider-dark'/>
                     {messageDisplaySection}
-                    <div className='divider-dark'/>
                     {channelDisplayModeSection}
-                    <div className='divider-dark'/>
                     {languagesSection}
                 </div>
             </div>


### PR DESCRIPTION
This PR currently hides theme, font and display name for display settings.

![screen shot 2016-11-02 at 4 55 03 pm](https://cloud.githubusercontent.com/assets/3249825/19951809/b51ff854-a11d-11e6-8e06-4222dfd8730d.png)

![screen shot 2016-11-02 at 4 59 37 pm](https://cloud.githubusercontent.com/assets/3249825/19951820/c4e46022-a11d-11e6-8a5f-905529f39a2f.png)
