### PR TITLE
Allow default team to be configured

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -51,7 +51,8 @@
         "RestrictPublicChannelManagement": "all",
         "RestrictPrivateChannelManagement": "all",
         "UserStatusAwayTimeout": 300,
-        "MaxChannelsPerTeam": 2000
+        "MaxChannelsPerTeam": 2000,
+        "DefaultTeam": ""
     },
     "SqlSettings": {
         "DriverName": "mysql",

--- a/model/config.go
+++ b/model/config.go
@@ -221,6 +221,7 @@ type TeamSettings struct {
 	RestrictPrivateChannelManagement *string
 	UserStatusAwayTimeout            *int64
 	MaxChannelsPerTeam               *int64
+	DefaultTeam                      *string
 }
 
 type LdapSettings struct {

--- a/model/config.go
+++ b/model/config.go
@@ -221,7 +221,7 @@ type TeamSettings struct {
 	RestrictPrivateChannelManagement *string
 	UserStatusAwayTimeout            *int64
 	MaxChannelsPerTeam               *int64
-	DefaultTeam                      *string
+	DefaultTeam                      string
 }
 
 type LdapSettings struct {

--- a/model/config.go
+++ b/model/config.go
@@ -221,7 +221,7 @@ type TeamSettings struct {
 	RestrictPrivateChannelManagement *string
 	UserStatusAwayTimeout            *int64
 	MaxChannelsPerTeam               *int64
-	DefaultTeam                      string
+	DefaultTeamName                  string
 }
 
 type LdapSettings struct {

--- a/utils/config.go
+++ b/utils/config.go
@@ -240,7 +240,7 @@ func getClientConfig(c *model.Config) map[string]string {
 	props["RestrictTeamInvite"] = *c.TeamSettings.RestrictTeamInvite
 	props["RestrictPublicChannelManagement"] = *c.TeamSettings.RestrictPublicChannelManagement
 	props["RestrictPrivateChannelManagement"] = *c.TeamSettings.RestrictPrivateChannelManagement
-	props["DefaultTeamName"] = c.TeamSettings.DefaultTeam
+	props["DefaultTeam"] = c.TeamSettings.DefaultTeam
 
 	props["EnableOAuthServiceProvider"] = strconv.FormatBool(c.ServiceSettings.EnableOAuthServiceProvider)
 	props["SegmentDeveloperKey"] = c.ServiceSettings.SegmentDeveloperKey

--- a/utils/config.go
+++ b/utils/config.go
@@ -240,7 +240,7 @@ func getClientConfig(c *model.Config) map[string]string {
 	props["RestrictTeamInvite"] = *c.TeamSettings.RestrictTeamInvite
 	props["RestrictPublicChannelManagement"] = *c.TeamSettings.RestrictPublicChannelManagement
 	props["RestrictPrivateChannelManagement"] = *c.TeamSettings.RestrictPrivateChannelManagement
-	props["DefaultTeamName"] = *c.TeamSettings.DefaultTeam
+	props["DefaultTeamName"] = c.TeamSettings.DefaultTeam
 
 	props["EnableOAuthServiceProvider"] = strconv.FormatBool(c.ServiceSettings.EnableOAuthServiceProvider)
 	props["SegmentDeveloperKey"] = c.ServiceSettings.SegmentDeveloperKey

--- a/utils/config.go
+++ b/utils/config.go
@@ -240,6 +240,7 @@ func getClientConfig(c *model.Config) map[string]string {
 	props["RestrictTeamInvite"] = *c.TeamSettings.RestrictTeamInvite
 	props["RestrictPublicChannelManagement"] = *c.TeamSettings.RestrictPublicChannelManagement
 	props["RestrictPrivateChannelManagement"] = *c.TeamSettings.RestrictPrivateChannelManagement
+	props["DefaultTeamName"] = *c.TeamSettings.DefaultTeam
 
 	props["EnableOAuthServiceProvider"] = strconv.FormatBool(c.ServiceSettings.EnableOAuthServiceProvider)
 	props["SegmentDeveloperKey"] = c.ServiceSettings.SegmentDeveloperKey

--- a/utils/config.go
+++ b/utils/config.go
@@ -240,7 +240,7 @@ func getClientConfig(c *model.Config) map[string]string {
 	props["RestrictTeamInvite"] = *c.TeamSettings.RestrictTeamInvite
 	props["RestrictPublicChannelManagement"] = *c.TeamSettings.RestrictPublicChannelManagement
 	props["RestrictPrivateChannelManagement"] = *c.TeamSettings.RestrictPrivateChannelManagement
-	props["DefaultTeam"] = c.TeamSettings.DefaultTeam
+	props["DefaultTeamName"] = c.TeamSettings.DefaultTeamName
 
 	props["EnableOAuthServiceProvider"] = strconv.FormatBool(c.ServiceSettings.EnableOAuthServiceProvider)
 	props["SegmentDeveloperKey"] = c.ServiceSettings.SegmentDeveloperKey

--- a/webapp/components/admin_console/users_and_teams_settings.jsx
+++ b/webapp/components/admin_console/users_and_teams_settings.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 
 import * as Utils from 'utils/utils.jsx';
 import Constants from 'utils/constants.jsx';
+import TeamStore from 'stores/team_store.jsx';
 
 import AdminSettings from './admin_settings.jsx';
 import BooleanSetting from './boolean_setting.jsx';
@@ -23,6 +24,16 @@ export default class UsersAndTeamsSettings extends AdminSettings {
         this.getConfigFromState = this.getConfigFromState.bind(this);
 
         this.renderSettings = this.renderSettings.bind(this);
+        this.teamValues = this.teamValues.bind(this);
+
+        this.state = this.getStateFromStores(false);
+    }
+
+    getStateFromStores() {
+        return {
+            ...this.state,
+            teams: TeamStore.getAll()
+        };
     }
 
     getConfigFromState(config) {
@@ -58,6 +69,19 @@ export default class UsersAndTeamsSettings extends AdminSettings {
                 />
             </h3>
         );
+    }
+
+    teamValues() {
+        const teamValues = [];
+        const teams = this.state.teams;
+
+        for (const id in teams) {
+            if (teams[id]) {
+                teamValues.push({value: teams[id].name, text: teams[id].display_name});
+            }
+        }
+        teamValues.unshift({value: '', text: 'No Defalut'});
+        return teamValues;
     }
 
     renderSettings() {
@@ -172,8 +196,9 @@ export default class UsersAndTeamsSettings extends AdminSettings {
                     value={this.state.restrictDirectMessage}
                     onChange={this.handleChange}
                 />
-                <TextSetting
+                <DropdownSetting
                     id='defaultTeam'
+                    values={this.teamValues()}
                     label={
                         <FormattedMessage
                             id='admin.team.defaultTeam'

--- a/webapp/components/admin_console/users_and_teams_settings.jsx
+++ b/webapp/components/admin_console/users_and_teams_settings.jsx
@@ -32,6 +32,7 @@ export default class UsersAndTeamsSettings extends AdminSettings {
         config.TeamSettings.RestrictCreationToDomains = this.state.restrictCreationToDomains;
         config.TeamSettings.RestrictDirectMessage = this.state.restrictDirectMessage;
         config.TeamSettings.MaxChannelsPerTeam = this.parseIntNonZero(this.state.maxChannelsPerTeam, Constants.DEFAULT_MAX_CHANNELS_PER_TEAM);
+        config.TeamSettings.DefaultTeam = this.state.defaultTeam;
 
         return config;
     }
@@ -43,7 +44,8 @@ export default class UsersAndTeamsSettings extends AdminSettings {
             maxUsersPerTeam: config.TeamSettings.MaxUsersPerTeam,
             restrictCreationToDomains: config.TeamSettings.RestrictCreationToDomains,
             restrictDirectMessage: config.TeamSettings.RestrictDirectMessage,
-            maxChannelsPerTeam: config.TeamSettings.MaxChannelsPerTeam
+            maxChannelsPerTeam: config.TeamSettings.MaxChannelsPerTeam,
+            defaultTeam: config.TeamSettings.DefaultTeam
         };
     }
 
@@ -168,6 +170,24 @@ export default class UsersAndTeamsSettings extends AdminSettings {
                         />
                     }
                     value={this.state.restrictDirectMessage}
+                    onChange={this.handleChange}
+                />
+                <TextSetting
+                    id='defaultTeam'
+                    label={
+                        <FormattedMessage
+                            id='admin.team.defaultTeam'
+                            defaultMessage='Set a default team:'
+                        />
+                    }
+                    placeholder={Utils.localizeMessage('admin.team.defaultTeam', 'Ex "example-team"')}
+                    helpText={
+                        <FormattedMessage
+                            id='admin.team.defaultTeam'
+                            defaultMessage='When set, users will be automatically redirected to this team page skipping the team selection page.'
+                        />
+                    }
+                    value={this.state.defaultTeam}
                     onChange={this.handleChange}
                 />
             </SettingsGroup>

--- a/webapp/components/admin_console/users_and_teams_settings.jsx
+++ b/webapp/components/admin_console/users_and_teams_settings.jsx
@@ -43,7 +43,7 @@ export default class UsersAndTeamsSettings extends AdminSettings {
         config.TeamSettings.RestrictCreationToDomains = this.state.restrictCreationToDomains;
         config.TeamSettings.RestrictDirectMessage = this.state.restrictDirectMessage;
         config.TeamSettings.MaxChannelsPerTeam = this.parseIntNonZero(this.state.maxChannelsPerTeam, Constants.DEFAULT_MAX_CHANNELS_PER_TEAM);
-        config.TeamSettings.DefaultTeam = this.state.defaultTeam;
+        config.TeamSettings.DefaultTeamName = this.state.DefaultTeamName;
 
         return config;
     }
@@ -56,7 +56,7 @@ export default class UsersAndTeamsSettings extends AdminSettings {
             restrictCreationToDomains: config.TeamSettings.RestrictCreationToDomains,
             restrictDirectMessage: config.TeamSettings.RestrictDirectMessage,
             maxChannelsPerTeam: config.TeamSettings.MaxChannelsPerTeam,
-            defaultTeam: config.TeamSettings.DefaultTeam
+            DefaultTeamName: config.TeamSettings.DefaultTeamName
         };
     }
 
@@ -197,22 +197,22 @@ export default class UsersAndTeamsSettings extends AdminSettings {
                     onChange={this.handleChange}
                 />
                 <DropdownSetting
-                    id='defaultTeam'
+                    id='DefaultTeamName'
                     values={this.teamValues()}
                     label={
                         <FormattedMessage
-                            id='admin.team.defaultTeam'
+                            id='admin.team.DefaultTeamName'
                             defaultMessage='Set a default team:'
                         />
                     }
-                    placeholder={Utils.localizeMessage('admin.team.defaultTeam', 'Ex "example-team"')}
+                    placeholder={Utils.localizeMessage('admin.team.DefaultTeamName', 'Ex "example-team"')}
                     helpText={
                         <FormattedMessage
-                            id='admin.team.defaultTeam'
+                            id='admin.team.DefaultTeamName'
                             defaultMessage='When set, users will be automatically redirected to this team page skipping the team selection page.'
                         />
                     }
-                    value={this.state.defaultTeam}
+                    value={this.state.DefaultTeamName}
                     onChange={this.handleChange}
                 />
             </SettingsGroup>

--- a/webapp/components/login/login_controller.jsx
+++ b/webapp/components/login/login_controller.jsx
@@ -21,7 +21,7 @@ import {browserHistory, Link} from 'react-router/es6';
 import React from 'react';
 import logoImage from 'images/logo.png';
 
-const DefaultTeamName = global.window.mm_config.DefaultTeamName;
+const DefaultTeam = global.window.mm_config.DefaultTeam;
 
 export default class LoginController extends React.Component {
     static get propTypes() {
@@ -59,8 +59,8 @@ export default class LoginController extends React.Component {
             browserHistory.push('/select_team');
         }
 
-        if (UserStore.getCurrentUser() && DefaultTeamName) {
-            browserHistory.push(`/${DefaultTeamName}/channels/town-square`);
+        if (UserStore.getCurrentUser() && DefaultTeam) {
+            browserHistory.push(`/${DefaultTeam}/channels/town-square`);
         }
 
         AsyncClient.checkVersion();
@@ -209,8 +209,8 @@ export default class LoginController extends React.Component {
                 GlobalActions.loadDefaultLocale();
                 if (query.redirect_to) {
                     browserHistory.push(query.redirect_to);
-                } else if (DefaultTeamName) {
-                    browserHistory.push(`/${DefaultTeamName}/channels/town-square`);
+                } else if (DefaultTeam) {
+                    browserHistory.push(`/${DefaultTeam}/channels/town-square`);
                 } else {
                     browserHistory.push('/select_team');
                 }

--- a/webapp/components/login/login_controller.jsx
+++ b/webapp/components/login/login_controller.jsx
@@ -21,7 +21,7 @@ import {browserHistory, Link} from 'react-router/es6';
 import React from 'react';
 import logoImage from 'images/logo.png';
 
-const DefaultTeam = global.window.mm_config.DefaultTeam;
+const config = global.window.mm_config;
 
 export default class LoginController extends React.Component {
     static get propTypes() {
@@ -42,10 +42,10 @@ export default class LoginController extends React.Component {
         this.handlePasswordChange = this.handlePasswordChange.bind(this);
 
         this.state = {
-            ldapEnabled: global.window.mm_license.IsLicensed === 'true' && global.window.mm_config.EnableLdap === 'true',
-            usernameSigninEnabled: global.window.mm_config.EnableSignInWithUsername === 'true',
-            emailSigninEnabled: global.window.mm_config.EnableSignInWithEmail === 'true',
-            samlEnabled: global.window.mm_license.IsLicensed === 'true' && global.window.mm_config.EnableSaml === 'true',
+            ldapEnabled: global.window.mm_license.IsLicensed === 'true' && config.EnableLdap === 'true',
+            usernameSigninEnabled: config.EnableSignInWithUsername === 'true',
+            emailSigninEnabled: config.EnableSignInWithEmail === 'true',
+            samlEnabled: global.window.mm_license.IsLicensed === 'true' && config.EnableSaml === 'true',
             loginId: '', // the browser will set a default for this
             password: '',
             showMfa: false
@@ -53,14 +53,14 @@ export default class LoginController extends React.Component {
     }
 
     componentDidMount() {
-        document.title = global.window.mm_config.SiteName;
+        document.title = config.SiteName;
 
         if (UserStore.getCurrentUser()) {
             browserHistory.push('/select_team');
         }
 
-        if (UserStore.getCurrentUser() && DefaultTeam) {
-            browserHistory.push(`/${DefaultTeam}/channels/town-square`);
+        if (UserStore.getCurrentUser() && config.DefaultTeam) {
+            browserHistory.push(`/${config.DefaultTeam}/channels/town-square`);
         }
 
         AsyncClient.checkVersion();
@@ -102,7 +102,7 @@ export default class LoginController extends React.Component {
                     <FormattedMessage
                         id={msgId}
                         values={{
-                            ldapUsername: global.window.mm_config.LdapLoginFieldName || Utils.localizeMessage('login.ldapUsernameLower', 'AD/LDAP username')
+                            ldapUsername: config.LdapLoginFieldName || Utils.localizeMessage('login.ldapUsernameLower', 'AD/LDAP username')
                         }}
                     />
                 )
@@ -122,7 +122,7 @@ export default class LoginController extends React.Component {
             return;
         }
 
-        if (global.window.mm_config.EnableMultifactorAuthentication === 'true') {
+        if (config.EnableMultifactorAuthentication === 'true') {
             Client.checkMfa(
                 loginId,
                 (data) => {
@@ -209,8 +209,8 @@ export default class LoginController extends React.Component {
                 GlobalActions.loadDefaultLocale();
                 if (query.redirect_to) {
                     browserHistory.push(query.redirect_to);
-                } else if (DefaultTeam) {
-                    browserHistory.push(`/${DefaultTeam}/channels/town-square`);
+                } else if (config.DefaultTeam) {
+                    browserHistory.push(`/${config.DefaultTeam}/channels/town-square`);
                 } else {
                     browserHistory.push('/select_team');
                 }
@@ -233,8 +233,8 @@ export default class LoginController extends React.Component {
     createCustomLogin() {
         if (global.window.mm_license.IsLicensed === 'true' &&
                 global.window.mm_license.CustomBrand === 'true' &&
-                global.window.mm_config.EnableCustomBrand === 'true') {
-            const text = global.window.mm_config.CustomBrandText || '';
+                config.EnableCustomBrand === 'true') {
+            const text = config.CustomBrandText || '';
 
             return (
                 <div>
@@ -264,8 +264,8 @@ export default class LoginController extends React.Component {
         }
 
         if (ldapEnabled) {
-            if (global.window.mm_config.LdapLoginFieldName) {
-                loginPlaceholders.push(global.window.mm_config.LdapLoginFieldName);
+            if (config.LdapLoginFieldName) {
+                loginPlaceholders.push(config.LdapLoginFieldName);
             } else {
                 loginPlaceholders.push(Utils.localizeMessage('login.ldapUsername', 'AD/LDAP Username'));
             }
@@ -283,12 +283,12 @@ export default class LoginController extends React.Component {
     }
 
     checkSignUpEnabled() {
-        return global.window.mm_config.EnableSignUpWithEmail === 'true' ||
-            global.window.mm_config.EnableSignUpWithGitLab === 'true' ||
-            global.window.mm_config.EnableSignUpWithOffice365 === 'true' ||
-            global.window.mm_config.EnableSignUpWithGoogle === 'true' ||
-            global.window.mm_config.EnableLdap === 'true' ||
-            global.window.mm_config.EnableSaml === 'true';
+        return config.EnableSignUpWithEmail === 'true' ||
+            config.EnableSignUpWithGitLab === 'true' ||
+            config.EnableSignUpWithOffice365 === 'true' ||
+            config.EnableSignUpWithGoogle === 'true' ||
+            config.EnableLdap === 'true' ||
+            config.EnableSaml === 'true';
     }
 
     createLoginOptions() {
@@ -341,9 +341,9 @@ export default class LoginController extends React.Component {
         const loginControls = [];
 
         const ldapEnabled = this.state.ldapEnabled;
-        const gitlabSigninEnabled = global.window.mm_config.EnableSignUpWithGitLab === 'true';
-        const googleSigninEnabled = global.window.mm_config.EnableSignUpWithGoogle === 'true';
-        const office365SigninEnabled = global.window.mm_config.EnableSignUpWithOffice365 === 'true';
+        const gitlabSigninEnabled = config.EnableSignUpWithGitLab === 'true';
+        const googleSigninEnabled = config.EnableSignUpWithGoogle === 'true';
+        const office365SigninEnabled = config.EnableSignUpWithOffice365 === 'true';
         const samlSigninEnabled = this.state.samlEnabled;
         const usernameSigninEnabled = this.state.usernameSigninEnabled;
         const emailSigninEnabled = this.state.emailSigninEnabled;
@@ -404,7 +404,7 @@ export default class LoginController extends React.Component {
             );
         }
 
-        if (global.window.mm_config.EnableOpenServer === 'true' && this.checkSignUpEnabled()) {
+        if (config.EnableOpenServer === 'true' && this.checkSignUpEnabled()) {
             loginControls.push(
                 <div
                     className='form-group'
@@ -591,8 +591,8 @@ export default class LoginController extends React.Component {
         }
 
         let description = null;
-        if (global.window.mm_license.IsLicensed === 'true' && global.window.mm_license.CustomBrand === 'true' && global.window.mm_config.EnableCustomBrand === 'true') {
-            description = global.window.mm_config.CustomDescriptionText;
+        if (global.window.mm_license.IsLicensed === 'true' && global.window.mm_license.CustomBrand === 'true' && config.EnableCustomBrand === 'true') {
+            description = config.CustomDescriptionText;
         } else {
             description = (
                 <FormattedMessage
@@ -615,7 +615,7 @@ export default class LoginController extends React.Component {
                             src={logoImage}
                         />
                         <div className='signup__content'>
-                            <h1>{global.window.mm_config.SiteName}</h1>
+                            <h1>{config.SiteName}</h1>
                             <h4 className='color--light'>
                                 {description}
                             </h4>

--- a/webapp/components/login/login_controller.jsx
+++ b/webapp/components/login/login_controller.jsx
@@ -21,6 +21,8 @@ import {browserHistory, Link} from 'react-router/es6';
 import React from 'react';
 import logoImage from 'images/logo.png';
 
+const DefaultTeamName = global.window.mm_config.DefaultTeamName;
+
 export default class LoginController extends React.Component {
     static get propTypes() {
         return {
@@ -55,6 +57,10 @@ export default class LoginController extends React.Component {
 
         if (UserStore.getCurrentUser()) {
             browserHistory.push('/select_team');
+        }
+
+        if (UserStore.getCurrentUser() && DefaultTeamName) {
+            browserHistory.push(`/${DefaultTeamName}/channels/town-square`);
         }
 
         AsyncClient.checkVersion();
@@ -203,6 +209,8 @@ export default class LoginController extends React.Component {
                 GlobalActions.loadDefaultLocale();
                 if (query.redirect_to) {
                     browserHistory.push(query.redirect_to);
+                } else if (DefaultTeamName) {
+                    browserHistory.push(`/${DefaultTeamName}/channels/town-square`);
                 } else {
                     browserHistory.push('/select_team');
                 }

--- a/webapp/components/login/login_controller.jsx
+++ b/webapp/components/login/login_controller.jsx
@@ -57,8 +57,8 @@ export default class LoginController extends React.Component {
             browserHistory.push('/select_team');
         }
 
-        if (UserStore.getCurrentUser() && global.window.mm_config.DefaultTeam) {
-            browserHistory.push(`/${global.window.mm_config.DefaultTeam}/channels/town-square`);
+        if (UserStore.getCurrentUser() && global.window.mm_config.DefaultTeamName) {
+            browserHistory.push(`/${global.window.mm_config.DefaultTeamName}/channels/town-square`);
         }
 
         AsyncClient.checkVersion();
@@ -207,8 +207,8 @@ export default class LoginController extends React.Component {
                 GlobalActions.loadDefaultLocale();
                 if (query.redirect_to) {
                     browserHistory.push(query.redirect_to);
-                } else if (global.window.mm_config.DefaultTeam) {
-                    browserHistory.push(`/${global.window.mm_config.DefaultTeam}/channels/town-square`);
+                } else if (global.window.mm_config.DefaultTeamName) {
+                    browserHistory.push(`/${global.window.mm_config.DefaultTeamName}/channels/town-square`);
                 } else {
                     browserHistory.push('/select_team');
                 }

--- a/webapp/components/login/login_controller.jsx
+++ b/webapp/components/login/login_controller.jsx
@@ -21,8 +21,6 @@ import {browserHistory, Link} from 'react-router/es6';
 import React from 'react';
 import logoImage from 'images/logo.png';
 
-const config = global.window.mm_config;
-
 export default class LoginController extends React.Component {
     static get propTypes() {
         return {
@@ -42,10 +40,10 @@ export default class LoginController extends React.Component {
         this.handlePasswordChange = this.handlePasswordChange.bind(this);
 
         this.state = {
-            ldapEnabled: global.window.mm_license.IsLicensed === 'true' && config.EnableLdap === 'true',
-            usernameSigninEnabled: config.EnableSignInWithUsername === 'true',
-            emailSigninEnabled: config.EnableSignInWithEmail === 'true',
-            samlEnabled: global.window.mm_license.IsLicensed === 'true' && config.EnableSaml === 'true',
+            ldapEnabled: global.window.mm_license.IsLicensed === 'true' && global.window.mm_config.EnableLdap === 'true',
+            usernameSigninEnabled: global.window.mm_config.EnableSignInWithUsername === 'true',
+            emailSigninEnabled: global.window.mm_config.EnableSignInWithEmail === 'true',
+            samlEnabled: global.window.mm_license.IsLicensed === 'true' && global.window.mm_config.EnableSaml === 'true',
             loginId: '', // the browser will set a default for this
             password: '',
             showMfa: false
@@ -53,14 +51,14 @@ export default class LoginController extends React.Component {
     }
 
     componentDidMount() {
-        document.title = config.SiteName;
+        document.title = global.window.mm_config.SiteName;
 
         if (UserStore.getCurrentUser()) {
             browserHistory.push('/select_team');
         }
 
-        if (UserStore.getCurrentUser() && config.DefaultTeam) {
-            browserHistory.push(`/${config.DefaultTeam}/channels/town-square`);
+        if (UserStore.getCurrentUser() && global.window.mm_config.DefaultTeam) {
+            browserHistory.push(`/${global.window.mm_config.DefaultTeam}/channels/town-square`);
         }
 
         AsyncClient.checkVersion();
@@ -102,7 +100,7 @@ export default class LoginController extends React.Component {
                     <FormattedMessage
                         id={msgId}
                         values={{
-                            ldapUsername: config.LdapLoginFieldName || Utils.localizeMessage('login.ldapUsernameLower', 'AD/LDAP username')
+                            ldapUsername: global.window.mm_config.LdapLoginFieldName || Utils.localizeMessage('login.ldapUsernameLower', 'AD/LDAP username')
                         }}
                     />
                 )
@@ -122,7 +120,7 @@ export default class LoginController extends React.Component {
             return;
         }
 
-        if (config.EnableMultifactorAuthentication === 'true') {
+        if (global.window.mm_config.EnableMultifactorAuthentication === 'true') {
             Client.checkMfa(
                 loginId,
                 (data) => {
@@ -209,8 +207,8 @@ export default class LoginController extends React.Component {
                 GlobalActions.loadDefaultLocale();
                 if (query.redirect_to) {
                     browserHistory.push(query.redirect_to);
-                } else if (config.DefaultTeam) {
-                    browserHistory.push(`/${config.DefaultTeam}/channels/town-square`);
+                } else if (global.window.mm_config.DefaultTeam) {
+                    browserHistory.push(`/${global.window.mm_config.DefaultTeam}/channels/town-square`);
                 } else {
                     browserHistory.push('/select_team');
                 }
@@ -233,8 +231,8 @@ export default class LoginController extends React.Component {
     createCustomLogin() {
         if (global.window.mm_license.IsLicensed === 'true' &&
                 global.window.mm_license.CustomBrand === 'true' &&
-                config.EnableCustomBrand === 'true') {
-            const text = config.CustomBrandText || '';
+                global.window.mm_config.EnableCustomBrand === 'true') {
+            const text = global.window.mm_config.CustomBrandText || '';
 
             return (
                 <div>
@@ -264,8 +262,8 @@ export default class LoginController extends React.Component {
         }
 
         if (ldapEnabled) {
-            if (config.LdapLoginFieldName) {
-                loginPlaceholders.push(config.LdapLoginFieldName);
+            if (global.window.mm_config.LdapLoginFieldName) {
+                loginPlaceholders.push(global.window.mm_config.LdapLoginFieldName);
             } else {
                 loginPlaceholders.push(Utils.localizeMessage('login.ldapUsername', 'AD/LDAP Username'));
             }
@@ -283,12 +281,12 @@ export default class LoginController extends React.Component {
     }
 
     checkSignUpEnabled() {
-        return config.EnableSignUpWithEmail === 'true' ||
-            config.EnableSignUpWithGitLab === 'true' ||
-            config.EnableSignUpWithOffice365 === 'true' ||
-            config.EnableSignUpWithGoogle === 'true' ||
-            config.EnableLdap === 'true' ||
-            config.EnableSaml === 'true';
+        return global.window.mm_config.EnableSignUpWithEmail === 'true' ||
+            global.window.mm_config.EnableSignUpWithGitLab === 'true' ||
+            global.window.mm_config.EnableSignUpWithOffice365 === 'true' ||
+            global.window.mm_config.EnableSignUpWithGoogle === 'true' ||
+            global.window.mm_config.EnableLdap === 'true' ||
+            global.window.mm_config.EnableSaml === 'true';
     }
 
     createLoginOptions() {
@@ -341,9 +339,9 @@ export default class LoginController extends React.Component {
         const loginControls = [];
 
         const ldapEnabled = this.state.ldapEnabled;
-        const gitlabSigninEnabled = config.EnableSignUpWithGitLab === 'true';
-        const googleSigninEnabled = config.EnableSignUpWithGoogle === 'true';
-        const office365SigninEnabled = config.EnableSignUpWithOffice365 === 'true';
+        const gitlabSigninEnabled = global.window.mm_config.EnableSignUpWithGitLab === 'true';
+        const googleSigninEnabled = global.window.mm_config.EnableSignUpWithGoogle === 'true';
+        const office365SigninEnabled = global.window.mm_config.EnableSignUpWithOffice365 === 'true';
         const samlSigninEnabled = this.state.samlEnabled;
         const usernameSigninEnabled = this.state.usernameSigninEnabled;
         const emailSigninEnabled = this.state.emailSigninEnabled;
@@ -404,7 +402,7 @@ export default class LoginController extends React.Component {
             );
         }
 
-        if (config.EnableOpenServer === 'true' && this.checkSignUpEnabled()) {
+        if (global.window.mm_config.EnableOpenServer === 'true' && this.checkSignUpEnabled()) {
             loginControls.push(
                 <div
                     className='form-group'
@@ -542,7 +540,7 @@ export default class LoginController extends React.Component {
                 >
                     <span className='icon fa fa-lock fa--margin-top'/>
                     <span>
-                        {window.mm_config.SamlLoginButtonText}
+                        {window.mm_global.window.mm_config.SamlLoginButtonText}
                     </span>
                 </a>
             );
@@ -591,8 +589,8 @@ export default class LoginController extends React.Component {
         }
 
         let description = null;
-        if (global.window.mm_license.IsLicensed === 'true' && global.window.mm_license.CustomBrand === 'true' && config.EnableCustomBrand === 'true') {
-            description = config.CustomDescriptionText;
+        if (global.window.mm_license.IsLicensed === 'true' && global.window.mm_license.CustomBrand === 'true' && global.window.mm_config.EnableCustomBrand === 'true') {
+            description = global.window.mm_config.CustomDescriptionText;
         } else {
             description = (
                 <FormattedMessage
@@ -615,7 +613,7 @@ export default class LoginController extends React.Component {
                             src={logoImage}
                         />
                         <div className='signup__content'>
-                            <h1>{config.SiteName}</h1>
+                            <h1>{global.window.mm_config.SiteName}</h1>
                             <h4 className='color--light'>
                                 {description}
                             </h4>

--- a/webapp/components/more_direct_channels.jsx
+++ b/webapp/components/more_direct_channels.jsx
@@ -21,6 +21,7 @@ import {FormattedMessage} from 'react-intl';
 import {browserHistory} from 'react-router/es6';
 
 const USERS_PER_PAGE = 50;
+const config = global.window.mm_config;
 
 export default class MoreDirectChannels extends React.Component {
     constructor(props) {
@@ -194,7 +195,7 @@ export default class MoreDirectChannels extends React.Component {
         }
 
         let teamToggle;
-        if (global.window.mm_config.RestrictDirectMessage === 'any') {
+        if (config.RestrictDirectMessage === 'any' && !config.DefaultTeam) {
             teamToggle = (
                 <div className='member-select__container'>
                     <select

--- a/webapp/components/more_direct_channels.jsx
+++ b/webapp/components/more_direct_channels.jsx
@@ -195,7 +195,7 @@ export default class MoreDirectChannels extends React.Component {
         }
 
         let teamToggle;
-        if (config.RestrictDirectMessage === 'any' && !config.DefaultTeam) {
+        if (config.RestrictDirectMessage === 'any' && !config.DefaultTeamName) {
             teamToggle = (
                 <div className='member-select__container'>
                     <select

--- a/webapp/components/root.jsx
+++ b/webapp/components/root.jsx
@@ -46,12 +46,12 @@ export default class Root extends React.Component {
     }
 
     redirectIfNecessary(props) {
-        const DefaultTeamName = global.window.mm_config.DefaultTeamName;
+        const DefaultTeam = global.window.mm_config.DefaultTeam;
         if (props.location.pathname === '/') {
             if (UserStore.getNoAccounts()) {
                 browserHistory.push('/signup_user_complete');
-            } else if (UserStore.getCurrentUser() && DefaultTeamName) {
-                browserHistory.push(`/${DefaultTeamName}/channels/town-square`);
+            } else if (UserStore.getCurrentUser() && DefaultTeam) {
+                browserHistory.push(`/${DefaultTeam}/channels/town-square`);
             } else if (UserStore.getCurrentUser()) {
                 browserHistory.push('/select_team');
             } else {

--- a/webapp/components/root.jsx
+++ b/webapp/components/root.jsx
@@ -46,9 +46,12 @@ export default class Root extends React.Component {
     }
 
     redirectIfNecessary(props) {
+        const DefaultTeamName = global.window.mm_config.DefaultTeamName;
         if (props.location.pathname === '/') {
             if (UserStore.getNoAccounts()) {
                 browserHistory.push('/signup_user_complete');
+            } else if (UserStore.getCurrentUser() && DefaultTeamName) {
+                browserHistory.push(`/${DefaultTeamName}/channels/town-square`);
             } else if (UserStore.getCurrentUser()) {
                 browserHistory.push('/select_team');
             } else {

--- a/webapp/components/root.jsx
+++ b/webapp/components/root.jsx
@@ -46,12 +46,12 @@ export default class Root extends React.Component {
     }
 
     redirectIfNecessary(props) {
-        const DefaultTeam = global.window.mm_config.DefaultTeam;
+        const DefaultTeamName = global.window.mm_config.DefaultTeamName;
         if (props.location.pathname === '/') {
             if (UserStore.getNoAccounts()) {
                 browserHistory.push('/signup_user_complete');
-            } else if (UserStore.getCurrentUser() && DefaultTeam) {
-                browserHistory.push(`/${DefaultTeam}/channels/town-square`);
+            } else if (UserStore.getCurrentUser() && DefaultTeamName) {
+                browserHistory.push(`/${DefaultTeamName}/channels/town-square`);
             } else if (UserStore.getCurrentUser()) {
                 browserHistory.push('/select_team');
             } else {

--- a/webapp/components/sidebar_header_dropdown.jsx
+++ b/webapp/components/sidebar_header_dropdown.jsx
@@ -335,7 +335,7 @@ export default class SidebarHeaderDropdown extends React.Component {
             );
         }
 
-        if (!config.DefaultTeam) {
+        if (!config.DefaultTeamName) {
             teams.push(
                 <li key='leaveTeam_li'>
                     <a

--- a/webapp/components/sidebar_header_dropdown.jsx
+++ b/webapp/components/sidebar_header_dropdown.jsx
@@ -335,47 +335,49 @@ export default class SidebarHeaderDropdown extends React.Component {
             );
         }
 
-        teams.push(
-            <li key='leaveTeam_li'>
-                <a
-                    href='#'
-                    onClick={GlobalActions.showLeaveTeamModal}
-                >
-                    <FormattedMessage
-                        id='navbar_dropdown.leave'
-                        defaultMessage='Leave Team'
-                    />
-                </a>
-            </li>
-        );
-
-        if (this.state.teamMembers && this.state.teamMembers.length > 1) {
+        if (!config.DefaultTeam) {
             teams.push(
-                <li
-                    key='teamDiv'
-                    className='divider'
-                />
+                <li key='leaveTeam_li'>
+                    <a
+                        href='#'
+                        onClick={GlobalActions.showLeaveTeamModal}
+                    >
+                        <FormattedMessage
+                            id='navbar_dropdown.leave'
+                            defaultMessage='Leave Team'
+                        />
+                    </a>
+                </li>
             );
 
-            for (var index in this.state.teamMembers) {
-                if (this.state.teamMembers.hasOwnProperty(index)) {
-                    var teamMember = this.state.teamMembers[index];
-                    var team = this.state.teams[teamMember.team_id];
+            if (this.state.teamMembers && this.state.teamMembers.length > 1) {
+                teams.push(
+                    <li
+                        key='teamDiv'
+                        className='divider'
+                    />
+                );
 
-                    if (team.name !== this.props.teamName) {
-                        teams.push(
-                            <li key={'team_' + team.name}>
-                                <Link
-                                    to={'/' + team.name + '/channels/town-square'}
-                                >
-                                    <FormattedMessage
-                                        id='navbar_dropdown.switchTo'
-                                        defaultMessage='Switch to '
-                                    />
-                                    {team.display_name}
-                                </Link>
-                            </li>
-                        );
+                for (var index in this.state.teamMembers) {
+                    if (this.state.teamMembers.hasOwnProperty(index)) {
+                        var teamMember = this.state.teamMembers[index];
+                        var team = this.state.teams[teamMember.team_id];
+
+                        if (team.name !== this.props.teamName) {
+                            teams.push(
+                                <li key={'team_' + team.name}>
+                                    <Link
+                                        to={'/' + team.name + '/channels/town-square'}
+                                    >
+                                        <FormattedMessage
+                                            id='navbar_dropdown.switchTo'
+                                            defaultMessage='Switch to '
+                                        />
+                                        {team.display_name}
+                                    </Link>
+                                </li>
+                            );
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This PR allows an admin user to manage a default team through the admin console.  When doing so, users will skip the choose a team selection page and be redirected to the default team chat page.

