### PR TITLE
Redesign mobile login

### DIFF
--- a/webapp/components/login/login_controller.jsx
+++ b/webapp/components/login/login_controller.jsx
@@ -380,7 +380,7 @@ export default class LoginController extends React.Component {
                                 spellCheck='false'
                             />
                         </div>
-                        <div className='form-group'>
+                        <div className='form-group pull-right'>
                             <button
                                 type='submit'
                                 className='btn btn-primary'
@@ -399,7 +399,7 @@ export default class LoginController extends React.Component {
         if (global.window.mm_config.EnableOpenServer === 'true' && this.checkSignUpEnabled()) {
             loginControls.push(
                 <div
-                    className='form-group'
+                    className='form-group hidden'
                     key='signup'
                 >
                     <span>
@@ -427,7 +427,10 @@ export default class LoginController extends React.Component {
                     key='forgotPassword'
                     className='form-group'
                 >
-                    <Link to={'/reset_password'}>
+                    <Link
+                        to={'/reset_password'}
+                        className='btn--link hidden'
+                    >
                         <FormattedMessage
                             id='login.forgot'
                             defaultMessage='I forgot my password'
@@ -607,8 +610,10 @@ export default class LoginController extends React.Component {
                             src={logoImage}
                         />
                         <div className='signup__content'>
-                            <h1>{global.window.mm_config.SiteName}</h1>
-                            <h4 className='color--light'>
+                            <h1 className='text-center'>
+                                {global.window.mm_config.SiteName}
+                            </h1>
+                            <h4 className='text-center color--light'>
                                 {description}
                             </h4>
                             {content}

--- a/webapp/sass/layout/_footer.scss
+++ b/webapp/sass/layout/_footer.scss
@@ -24,6 +24,7 @@
 .footer,
 .footer-pane,
 .footer-push {
+    display: none !important;
     height: 89px;
 }
 

--- a/webapp/sass/responsive/_mobile.scss
+++ b/webapp/sass/responsive/_mobile.scss
@@ -812,7 +812,6 @@
     .footer,
     .footer-pane,
     .footer-push {
-        display: none !important;
         height: 187px;
     }
 

--- a/webapp/sass/responsive/_mobile.scss
+++ b/webapp/sass/responsive/_mobile.scss
@@ -812,6 +812,7 @@
     .footer,
     .footer-pane,
     .footer-push {
+        display: none !important;
         height: 187px;
     }
 

--- a/webapp/sass/routes/_signup.scss
+++ b/webapp/sass/routes/_signup.scss
@@ -197,8 +197,8 @@
     .btn {
         font-size: 1em;
         font-weight: 600;
-        margin-right: 5px;
         padding: em(7px) em(15px);
+        min-width: em(110px);
 
         .fa {
             font-size: 17px;
@@ -329,6 +329,13 @@
 
         &.btn-default {
             color: #444444;
+        }
+
+        &--link {
+            display: inline-block;
+            padding: em(7px) 0;
+            border: 1px solid transparent;
+            vertical-align: middle;
         }
 
         .fa {


### PR DESCRIPTION
- Hide footer on mobile. @csduarte Should we hide the footer on all screen sizes?
- Hide "Create New Account" text/button on all screen sizes
- Hide "I forgot my password" link on all screen sizes
- Add new `.btn--link` class makes links behave like buttons while retaining the default link aesthetic (currently scoped exclusively to `.signup-team__container`).
- Set minimum button width scoped to signup__container (currently scoped exclusively to `.signup-team__container`)
- Right-align sign in button for better usability for the majority of users.