### PR TITLE
Set custom style for instances of `.modal-header .btn-primary`

### DIFF
--- a/webapp/sass/components/_modal.scss
+++ b/webapp/sass/components/_modal.scss
@@ -198,6 +198,7 @@
                     float: right;
                     margin: -4px 33px 0 0;
                     position: relative;
+                    border-color: #fff;
 
                     i {
                         margin-right: 5px;


### PR DESCRIPTION
Fixes the aesthetic of `.modal-header .btn-primary` set by the `theme.sidebarHeaderBg` variable, adding a small white stroke.

I checked every instance of `.modal-header` in use and the use of the theme variable. This change should be safe for future additions to mattermost/master.