### PR TITLE
TSDEV-143 fix aspect ratio issue with rectangular profile images

### DIFF
--- a/webapp/components/profile_picture.jsx
+++ b/webapp/components/profile_picture.jsx
@@ -102,7 +102,7 @@ export default class ProfilePicture extends React.Component {
                 >
                     <span className={`status-wrapper ${statusClass}`}>
                         <img
-                            className={`more-modal__image ${isSystemMessage && 'icon--uchat'}`}
+                            className={`more-modal__image ${isSystemMessage ? 'icon--uchat' : ''}`}
                             width={this.props.width}
                             height={this.props.width}
                             src={this.props.src}
@@ -114,7 +114,7 @@ export default class ProfilePicture extends React.Component {
         return (
             <span className={`status-wrapper ${statusClass}`}>
                 <img
-                    className={`more-modal__image ${isSystemMessage && 'icon--uchat'}`}
+                    className={`more-modal__image ${isSystemMessage ? 'icon--uchat' : ''}`}
                     width={this.props.width}
                     height={this.props.width}
                     src={this.props.src}

--- a/webapp/sass/components/_modal.scss
+++ b/webapp/sass/components/_modal.scss
@@ -572,6 +572,7 @@
         flex-shrink: 0;
         margin-top: 2px;
         max-width: none;
+        object-fit: cover;
 
         .status-wrapper {
             &:after {

--- a/webapp/sass/components/_popover.scss
+++ b/webapp/sass/components/_popover.scss
@@ -56,6 +56,7 @@
 .user-popover__image {
     @include border-radius(128px);
     margin: 0 0 10px;
+    object-fit: cover;
 }
 
 .user-popover__email {

--- a/webapp/sass/layout/_headers.scss
+++ b/webapp/sass/layout/_headers.scss
@@ -315,6 +315,7 @@
             height: 36px;
             margin-right: 6px;
             width: 36px;
+            object-fit: cover;
         }
 
         .header__info {

--- a/webapp/sass/layout/_post.scss
+++ b/webapp/sass/layout/_post.scss
@@ -874,6 +874,7 @@
             vertical-align: inherit;
             width: 32px;
             max-width:none;
+            object-fit: cover;
         }
 
         .icon--uchat {


### PR DESCRIPTION
Use `object-fit: cover;` in various places to allow scaling while preserving aspect ratio on profile pictures

Before:
<img width="170" alt="screen shot 2016-11-18 at 10 08 20 am" src="https://cloud.githubusercontent.com/assets/910657/20441159/371f84ee-ad78-11e6-8a67-b5c80f10866b.png">

After:
<img width="165" alt="screen shot 2016-11-18 at 10 08 09 am" src="https://cloud.githubusercontent.com/assets/910657/20441166/3bf3b15c-ad78-11e6-9b1e-61b1247a5dfc.png">


