### PR TITLE
UCHAT-122 remove the dangling help link near text input

### DIFF
--- a/webapp/components/textbox.jsx
+++ b/webapp/components/textbox.jsx
@@ -133,77 +133,29 @@ export default class Textbox extends React.Component {
     }
 
     render() {
-        const hasText = this.props.value && this.props.value.length > 0;
-
         let previewLink = null;
         if (Utils.isFeatureEnabled(PreReleaseFeatures.MARKDOWN_PREVIEW)) {
             previewLink = (
-                <a
-                    onClick={this.showPreview}
-                    className='textbox-preview-link'
-                >
-                    {this.state.preview ? (
-                        <FormattedMessage
-                            id='textbox.edit'
-                            defaultMessage='Edit message'
-                        />
-                    ) : (
-                        <FormattedMessage
-                            id='textbox.preview'
-                            defaultMessage='Preview'
-                        />
-                    )}
-                </a>
+                <div className='md-preview__text'>
+                    <a
+                        onClick={this.showPreview}
+                        className='textbox-preview-link'
+                    >
+                        {this.state.preview ? (
+                            <FormattedMessage
+                                id='textbox.edit'
+                                defaultMessage='Edit message'
+                            />
+                        ) : (
+                            <FormattedMessage
+                                id='textbox.preview'
+                                defaultMessage='Preview'
+                            />
+                        )}
+                    </a>
+                </div>
             );
         }
-
-        const helpText = (
-            <div
-                style={{visibility: hasText ? 'visible' : 'hidden', opacity: hasText ? '0.45' : '0'}}
-                className='help__format-text'
-            >
-                <b>
-                    <FormattedMessage
-                        id='textbox.bold'
-                        defaultMessage='**bold**'
-                    />
-                </b>
-                <i>
-                    <FormattedMessage
-                        id='textbox.italic'
-                        defaultMessage='_italic_'
-                    />
-                </i>
-                <span>
-                    {'~~'}
-                    <strike>
-                        <FormattedMessage
-                            id='textbox.strike'
-                            defaultMessage='strike'
-                        />
-                    </strike>
-                    {'~~ '}
-                </span>
-                <span>
-                    <FormattedMessage
-                        id='textbox.inlinecode'
-                        defaultMessage='`inline code`'
-                    />
-                </span>
-                <span>
-                    <FormattedMessage
-                        id='textbox.preformatted'
-                        defaultMessage='```preformatted```'
-                    />
-                </span>
-                <span>
-                    <FormattedMessage
-                        id='textbox.quote'
-                        defaultMessage='>quote'
-                    />
-                </span>
-            </div>
-        );
 
         return (
             <div
@@ -236,21 +188,7 @@ export default class Textbox extends React.Component {
                     style={{display: this.state.preview ? 'block' : 'none'}}
                     dangerouslySetInnerHTML={{__html: this.state.preview ? TextFormatting.formatText(this.props.value) : ''}}
                 />
-                <div className='help__text'>
-                    {helpText}
-                    {previewLink}
-                    <a
-                        target='_blank'
-                        rel='noopener noreferrer'
-                        href='/help/messaging'
-                        className='textbox-help-link'
-                    >
-                        <FormattedMessage
-                            id='textbox.help'
-                            defaultMessage='Help'
-                        />
-                    </a>
-                </div>
+                {previewLink}
             </div>
         );
     }

--- a/webapp/sass/layout/_post.scss
+++ b/webapp/sass/layout/_post.scss
@@ -35,7 +35,7 @@
         z-index: 2;
     }
 
-    .help__text {
+    .md-preview__text {
         bottom: -23px;
         cursor: pointer;
         font-size: 13px;


### PR DESCRIPTION
Currently, in Mattermost and our version, there's a dangling "Help" link if the user types more than one line of text in the input box:
<img width="428" alt="screen shot 2016-11-18 at 3 33 20 pm" src="https://cloud.githubusercontent.com/assets/910657/20451726/b6f7a0aa-adb1-11e6-922a-fdfb85b53de5.png">
<img width="741" alt="screen shot 2016-11-18 at 3 22 01 pm" src="https://cloud.githubusercontent.com/assets/910657/20451798/a2554912-adb2-11e6-896f-4d64b31baa48.png">
This PR removes the "Help" link which seems to be from a disabled feature.
