### PR TITLE
UCHAT-122 hide help link properly for tablet sized screens

### DIFF
--- a/webapp/components/create_post.jsx
+++ b/webapp/components/create_post.jsx
@@ -24,7 +24,7 @@ import PreferenceStore from 'stores/preference_store.jsx';
 
 import Constants from 'utils/constants.jsx';
 
-import {FormattedHTMLMessage} from 'react-intl';
+import {FormattedMessage, FormattedHTMLMessage} from 'react-intl';
 import {browserHistory} from 'react-router/es6';
 
 const Preferences = Constants.Preferences;
@@ -489,6 +489,54 @@ export default class CreatePost extends React.Component {
             centerClass = 'center';
         }
 
+        const helpText = (
+            <div
+                style={{visibility: this.state.message ? 'visible' : 'hidden', opacity: this.state.message ? '0.45' : '0'}}
+                className='help__format-text'
+            >
+                <b>
+                    <FormattedMessage
+                        id='textbox.bold'
+                        defaultMessage='**bold**'
+                    />
+                </b>
+                <i>
+                    <FormattedMessage
+                        id='textbox.italic'
+                        defaultMessage='_italic_'
+                    />
+                </i>
+                <span>
+                    {'~~'}
+                    <strike>
+                        <FormattedMessage
+                            id='textbox.strike'
+                            defaultMessage='strike'
+                        />
+                    </strike>
+                    {'~~ '}
+                </span>
+                <span>
+                    <FormattedMessage
+                        id='textbox.inlinecode'
+                        defaultMessage='`inline code`'
+                    />
+                </span>
+                <span>
+                    <FormattedMessage
+                        id='textbox.preformatted'
+                        defaultMessage='```preformatted```'
+                    />
+                </span>
+                <span>
+                    <FormattedMessage
+                        id='textbox.quote'
+                        defaultMessage='>quote'
+                    />
+                </span>
+            </div>
+        );
+
         return (
             <form
                 id='create_post'
@@ -538,6 +586,20 @@ export default class CreatePost extends React.Component {
                         {preview}
                         {postError}
                         {serverError}
+                        <div className='help__text'>
+                            {helpText}
+                            <a
+                                target='_blank'
+                                rel='noopener noreferrer'
+                                href='/help/messaging'
+                                className='textbox-help-link'
+                            >
+                                <FormattedMessage
+                                    id='textbox.help'
+                                    defaultMessage='Help'
+                                />
+                            </a>
+                        </div>
                     </div>
                 </div>
                 <PostDeletedModal

--- a/webapp/sass/layout/_post.scss
+++ b/webapp/sass/layout/_post.scss
@@ -408,6 +408,16 @@
             position: relative;
             top: -5px;
         }
+
+        .help__text {
+            bottom: 6px;
+            right: 15px;
+            cursor: pointer;
+            font-size: 13px;
+            position: absolute;
+            text-align: right;
+            z-index: 3;
+        }
     }
 
     .msg-typing {

--- a/webapp/sass/responsive/_tablet.scss
+++ b/webapp/sass/responsive/_tablet.scss
@@ -25,6 +25,10 @@
                 display: none;
             }
 
+            .help__text {
+                display: none;
+            }
+
             .control-label {
                 top: 0;
             }


### PR DESCRIPTION
After some further investigation, the dangling help link is caused by the `help__text` being inside the `textbox.jsx` component instead of `post-create-footer`, so when the responsive layout is being applied, the help link does not get hidden.

This commit moves the `help__text` div into the proper container and hide it in mobile and tablet layout.

Desktop layout:
<img width="462" alt="screen shot 2016-11-21 at 11 13 05 am" src="https://cloud.githubusercontent.com/assets/910657/20497368/bdc891cc-afdd-11e6-9a19-99ca7697d612.png">
Tablet/Mobile layout:
<img width="328" alt="screen shot 2016-11-21 at 11 29 44 am" src="https://cloud.githubusercontent.com/assets/910657/20497396/d05815f6-afdd-11e6-9332-1091cf1c3fc6.png">
