### PR TITLE
UCHAT-60 change default notification settings for new users

### DIFF
--- a/model/user.go
+++ b/model/user.go
@@ -173,10 +173,12 @@ func (u *User) SetDefaultNotifications() {
 	u.NotifyProps = make(map[string]string)
 	u.NotifyProps["email"] = "true"
 	u.NotifyProps["push"] = USER_NOTIFY_MENTION
-	u.NotifyProps["desktop"] = USER_NOTIFY_ALL
-	u.NotifyProps["desktop_sound"] = "true"
+	u.NotifyProps["push_status"] = STATUS_AWAY
+	u.NotifyProps["desktop"] = USER_NOTIFY_MENTION
+	u.NotifyProps["desktop_sound"] = "false"
 	u.NotifyProps["mention_keys"] = u.Username + ",@" + u.Username
 	u.NotifyProps["channel"] = "true"
+	u.NotifyProps["comments"] = "root"
 
 	if u.FirstName == "" {
 		u.NotifyProps["first_name"] = "false"

--- a/webapp/components/post_view/components/post_list.jsx
+++ b/webapp/components/post_view/components/post_list.jsx
@@ -284,7 +284,7 @@ export default class PostList extends React.Component {
             }
 
             if (parentPost && commentRootId) {
-                const commentsNotifyLevel = this.props.currentUser.notify_props.comments || 'never';
+                const commentsNotifyLevel = this.props.currentUser.notify_props.comments || 'root';
                 const notCurrentUser = post.user_id !== userId || (post.props && post.props.from_webhook);
                 if (notCurrentUser) {
                     if (commentsNotifyLevel === 'any' && (posts[commentRootId].user_id === userId || shouldHighlightThreads)) {

--- a/webapp/components/user_settings/user_settings_notifications.jsx
+++ b/webapp/components/user_settings/user_settings_notifications.jsx
@@ -25,7 +25,7 @@ function getNotificationsStateFromStores() {
     let comments = 'never';
     let enableEmail = 'true';
     let pushActivity = 'mention';
-    let pushStatus = Constants.UserStatuses.ONLINE;
+    let pushStatus = Constants.UserStatuses.AWAY;
 
     if (user.notify_props) {
         if (user.notify_props.desktop) {


### PR DESCRIPTION
For new users, the function `SetDefaultNotifications` is called. However, some of the default values are currently being set in the webapp itself. This PR changes some of the default notification values, and set the missing fields from the server.

Note: I verified from them webapp UI that the new defaults are being displayed, but I have not completed a thorough test on whether if these notifications settings are indeed working.