### PR TITLE
UCHAT-13 close modal when clicking background

### DIFF
--- a/webapp/components/navbar.jsx
+++ b/webapp/components/navbar.jsx
@@ -671,6 +671,7 @@ export default class Navbar extends React.Component {
                     bsStyle='info'
                     placement='bottom'
                     id='header-popover'
+                    onClick={() => this.refs.headerOverlay.hide()}
                 >
                     <MessageWrapper
                         message={channel.header}
@@ -715,6 +716,7 @@ export default class Navbar extends React.Component {
                         bsStyle='info'
                         placement='bottom'
                         id='header-popover'
+                        onClick={() => this.refs.headerOverlay.hide()}
                     >
                         <div>
                             <FormattedMessage


### PR DESCRIPTION
This PR adds an onClick listener to Popover, so the modal gets closed when the user clicks on it on mobile. The drawback to this approach is the modal gets closed when the user touches anywhere on it. 

The reason why the default modal's "root close" behavior does not seem to work is because of the way this mobile CSS styling is being overridden. Popover component in `react-bootstrap` just looks like a tooltip, so when the user clicks anywhere "outside", the hide code is triggered. However, here it's being stretched into a fullscreen overlay, so there's nowhere that's considered "outside", so the closing code is never being triggered (unless the user clicks on the nav bar).