### PR TITLE
UCHAT-78 Configure app url scheme/intent for android app

### DIFF
--- a/webapp/components/get_android_app/get_android_app.jsx
+++ b/webapp/components/get_android_app/get_android_app.jsx
@@ -20,7 +20,7 @@ export default class GetAndroidApp extends React.Component {
                 >
                     <FormattedMessage
                         id='get_app.openMattermost'
-                        defaultMessage='Download the uChat App'
+                        defaultMessage='Use the uChat App'
                     />
                 </a>
                 <a


### PR DESCRIPTION
Changed text from 'Download' to 'Use' to better reflect the case new case that if the user has the app installed it will open the uChat Android app.
IMPORTANT: on the go configuration the value of `AndroidAppDownloadLink` needs to be set to `https://prod.com/downloads`

![uchat-use_android_app](https://cloud.githubusercontent.com/assets/160621/20544187/c9eb6872-b0d6-11e6-86d8-6aecd3f7deb6.png)

