### PR TITLE
UCHAT-202 Move next button to bottom of results list in paginated modals

### DIFF
--- a/api/channel.go
+++ b/api/channel.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"strconv"
 
 	l4g "github.com/alecthomas/log4go"
 

--- a/api/channel.go
+++ b/api/channel.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
-	"strconv"
 
 	l4g "github.com/alecthomas/log4go"
 

--- a/webapp/components/channel_invite_modal.jsx
+++ b/webapp/components/channel_invite_modal.jsx
@@ -170,18 +170,6 @@ export default class ChannelInviteModal extends React.Component {
                     {inviteError}
                     {content}
                 </Modal.Body>
-                <Modal.Footer>
-                    <button
-                        type='button'
-                        className='btn btn-default'
-                        onClick={this.onHide}
-                    >
-                        <FormattedMessage
-                            id='channel_invite.close'
-                            defaultMessage='Close'
-                        />
-                    </button>
-                </Modal.Footer>
             </Modal>
         );
     }

--- a/webapp/components/channel_members_modal.jsx
+++ b/webapp/components/channel_members_modal.jsx
@@ -196,18 +196,6 @@ export default class ChannelMembersModal extends React.Component {
                     >
                         {content}
                     </Modal.Body>
-                    <Modal.Footer>
-                        <button
-                            type='button'
-                            className='btn btn-default'
-                            onClick={this.onHide}
-                        >
-                            <FormattedMessage
-                                id='channel_members_modal.close'
-                                defaultMessage='Close'
-                            />
-                        </button>
-                    </Modal.Footer>
                 </Modal>
             </div>
         );

--- a/webapp/components/more_channels_list.jsx
+++ b/webapp/components/more_channels_list.jsx
@@ -158,6 +158,24 @@ export default class MoreChannelsList extends React.Component {
             );
         }
 
+        let channelsContent = '';
+        if (channelsToDisplay.length > 0) {
+            channelsContent = channelsToDisplay.map(this.createChannelRow);
+        } else {
+            if (this.props.isSearch) {
+                channelsContent = (
+                    <div className='no-channel-message'>
+                        <p className='primary-message'>
+                            <FormattedMessage
+                                id='more_channels.noChannelsFound'
+                                defaultMessage='No channels found'
+                            />
+                        </p>
+                    </div>
+                );
+            }
+        }
+
         return (
             <div className='filtered-user-list'>
                 <div className='filter-row'>
@@ -178,7 +196,7 @@ export default class MoreChannelsList extends React.Component {
                     ref='channelList'
                     className='more-modal__list'
                 >
-                    {channelsToDisplay.map(this.createChannelRow)}
+                    {channelsContent}
                     {nextButton}
                 </div>
             </div>
@@ -188,7 +206,8 @@ export default class MoreChannelsList extends React.Component {
 
 MoreChannelsList.defaultProps = {
     channels: [],
-    channelsPerPage: 50 //eslint-disable-line no-magic-numbers
+    channelsPerPage: 50, //eslint-disable-line no-magic-numbers
+    isSearch: false
 };
 
 MoreChannelsList.propTypes = {
@@ -197,5 +216,6 @@ MoreChannelsList.propTypes = {
     channelsPerPage: React.PropTypes.number,
     total: React.PropTypes.number,
     nextPage: React.PropTypes.func.isRequired,
-    search: React.PropTypes.func.isRequired
+    search: React.PropTypes.func.isRequired,
+    isSearch: React.PropTypes.bool
 };

--- a/webapp/components/more_channels_list.jsx
+++ b/webapp/components/more_channels_list.jsx
@@ -194,7 +194,7 @@ export default class MoreChannelsList extends React.Component {
             );
         }
 
-        const height = $(window).height() - ($(window).width() <= 768 ? 100 : 170);
+        const height = $(window).height() - ($(window).width() <= 768 ? 120 : 170);
 
         return (
             <div

--- a/webapp/components/more_channels_list.jsx
+++ b/webapp/components/more_channels_list.jsx
@@ -19,7 +19,6 @@ export default class MoreChannelsList extends React.Component {
         super(props);
 
         this.nextPage = this.nextPage.bind(this);
-        //this.previousPage = this.previousPage.bind(this);
         this.handleFilterChange = this.handleFilterChange.bind(this);
         this.createChannelRow = this.createChannelRow.bind(this);
 
@@ -47,26 +46,12 @@ export default class MoreChannelsList extends React.Component {
         }
     }
 
-    componentDidUpdate(prevProps, prevState) {
-        /*
-        if (this.state.page !== prevState.page) {
-            $(ReactDOM.findDOMNode(this.refs.channelList)).scrollTop(0);
-        }
-        */
-    }
-
     nextPage(e) {
         e.preventDefault();
         this.setState({page: this.state.page + 1, nextDisabled: true});
         this.nextTimeoutId = setTimeout(() => this.setState({nextDisabled: false}), NEXT_BUTTON_TIMEOUT);
         this.props.nextPage(this.state.page + 1);
     }
-    /*
-    previousPage(e) {
-        e.preventDefault();
-        this.setState({page: this.state.page - 1});
-    }
-    */
 
     clearFilters(channels) {
         this.setState({filter: '', channels});
@@ -136,16 +121,7 @@ export default class MoreChannelsList extends React.Component {
         const channels = Object.values(this.state.channels);
 
         let nextButton;
-        // let previousButton;
         let count;
-        /*
-        const startCount = this.state.page * this.props.channelsPerPage;
-        let endCount = startCount + this.props.channelsPerPage;
-        if (this.props.total < endCount) {
-            endCount = this.props.total;
-        }
-        const channelsToDisplay = channels.slice(startCount, endCount);
-        */
         const startCount = 0;
         const endCount = (this.state.page + 1) * this.props.channelsPerPage;
         const channelsToDisplay = channels.slice(startCount, endCount);
@@ -166,18 +142,6 @@ export default class MoreChannelsList extends React.Component {
                 </div>
             );
         }
-        /*
-        if (this.state.page > 0) {
-            previousButton = (
-                <button
-                    className='btn btn-default filter-control filter-control__prev'
-                    onClick={this.previousPage}
-                >
-                    {'Previous'}
-                </button>
-            );
-        }
-        */
 
         if (this.props.total) {
             count = (
@@ -194,13 +158,8 @@ export default class MoreChannelsList extends React.Component {
             );
         }
 
-        const height = $(window).height() - ($(window).width() <= 768 ? 120 : 170);
-
         return (
-            <div
-                className='filtered-user-list'
-                style={{'max-height': `${height}px`}}
-            >
+            <div className='filtered-user-list'>
                 <div className='filter-row'>
                     <div className='col-sm-12'>
                         <input

--- a/webapp/components/more_channels_list.jsx
+++ b/webapp/components/more_channels_list.jsx
@@ -4,6 +4,7 @@
 import $ from 'jquery';
 import ReactDOM from 'react-dom';
 import * as UserAgent from 'utils/user_agent.jsx';
+import SpinnerButton from 'components/spinner_button.jsx';
 
 import {localizeMessage} from 'utils/utils.jsx';
 import {FormattedMessage} from 'react-intl';
@@ -18,7 +19,7 @@ export default class MoreChannelsList extends React.Component {
         super(props);
 
         this.nextPage = this.nextPage.bind(this);
-        this.previousPage = this.previousPage.bind(this);
+        //this.previousPage = this.previousPage.bind(this);
         this.handleFilterChange = this.handleFilterChange.bind(this);
         this.createChannelRow = this.createChannelRow.bind(this);
 
@@ -47,9 +48,11 @@ export default class MoreChannelsList extends React.Component {
     }
 
     componentDidUpdate(prevProps, prevState) {
+        /*
         if (this.state.page !== prevState.page) {
             $(ReactDOM.findDOMNode(this.refs.channelList)).scrollTop(0);
         }
+        */
     }
 
     nextPage(e) {
@@ -58,11 +61,12 @@ export default class MoreChannelsList extends React.Component {
         this.nextTimeoutId = setTimeout(() => this.setState({nextDisabled: false}), NEXT_BUTTON_TIMEOUT);
         this.props.nextPage(this.state.page + 1);
     }
-
+    /*
     previousPage(e) {
         e.preventDefault();
         this.setState({page: this.state.page - 1});
     }
+    */
 
     clearFilters(channels) {
         this.setState({filter: '', channels});
@@ -125,34 +129,44 @@ export default class MoreChannelsList extends React.Component {
     handleFilterChange(e) {
         this.setState({page: 0, filter: e.target.value});
         this.props.search(e.target.value);
+        $(ReactDOM.findDOMNode(this.refs.channelList)).scrollTop(0);
     }
 
     render() {
         const channels = Object.values(this.state.channels);
 
         let nextButton;
-        let previousButton;
+        // let previousButton;
         let count;
-
+        /*
         const startCount = this.state.page * this.props.channelsPerPage;
         let endCount = startCount + this.props.channelsPerPage;
         if (this.props.total < endCount) {
             endCount = this.props.total;
         }
         const channelsToDisplay = channels.slice(startCount, endCount);
+        */
+        const startCount = 0;
+        const endCount = (this.state.page + 1) * this.props.channelsPerPage;
+        const channelsToDisplay = channels.slice(startCount, endCount);
 
         if (endCount < this.props.total) {
             nextButton = (
-                <button
-                    className='btn btn-default filter-control filter-control__next'
-                    onClick={this.nextPage}
-                    disabled={this.state.nextDisabled}
-                >
-                    {'Next'}
-                </button>
+                <div style={{'text-align': 'center'}}>
+                    <SpinnerButton
+                        className='btn btn-default filter-control filter-control__next'
+                        onClick={this.nextPage}
+                        spinning={this.state.nextDisabled}
+                    >
+                        <FormattedMessage
+                            id='more_direct_channels.load_more'
+                            defaultMessage='Load more'
+                        />
+                    </SpinnerButton>
+                </div>
             );
         }
-
+        /*
         if (this.state.page > 0) {
             previousButton = (
                 <button
@@ -163,6 +177,7 @@ export default class MoreChannelsList extends React.Component {
                 </button>
             );
         }
+        */
 
         if (this.props.total) {
             count = (
@@ -179,8 +194,13 @@ export default class MoreChannelsList extends React.Component {
             );
         }
 
+        const height = $(window).height() - ($(window).width() <= 768 ? 100 : 170);
+
         return (
-            <div className='filtered-user-list'>
+            <div
+                className='filtered-user-list'
+                style={{...this.props.style, 'max-height': `${height}px`}}
+            >
                 <div className='filter-row'>
                     <div className='col-sm-12'>
                         <input
@@ -200,9 +220,6 @@ export default class MoreChannelsList extends React.Component {
                     className='more-modal__list'
                 >
                     {channelsToDisplay.map(this.createChannelRow)}
-                </div>
-                <div className='filter-controls'>
-                    {previousButton}
                     {nextButton}
                 </div>
             </div>

--- a/webapp/components/more_channels_list.jsx
+++ b/webapp/components/more_channels_list.jsx
@@ -161,19 +161,17 @@ export default class MoreChannelsList extends React.Component {
         let channelsContent = '';
         if (channelsToDisplay.length > 0) {
             channelsContent = channelsToDisplay.map(this.createChannelRow);
-        } else {
-            if (this.props.isSearch) {
-                channelsContent = (
-                    <div className='no-channel-message'>
-                        <p className='primary-message'>
-                            <FormattedMessage
-                                id='more_channels.noChannelsFound'
-                                defaultMessage='No channels found'
-                            />
-                        </p>
-                    </div>
-                );
-            }
+        } else if (this.props.isSearch) {
+            channelsContent = (
+                <div className='no-channel-message'>
+                    <p className='primary-message'>
+                        <FormattedMessage
+                            id='more_channels.noChannelsFound'
+                            defaultMessage='No channels found'
+                        />
+                    </p>
+                </div>
+            );
         }
 
         return (

--- a/webapp/components/more_channels_list.jsx
+++ b/webapp/components/more_channels_list.jsx
@@ -68,6 +68,15 @@ export default class MoreChannelsList extends React.Component {
         this.setState({filter: '', channels});
     }
 
+<<<<<<< HEAD
+=======
+    componentDidUpdate(prevProps, prevState) {
+        if (prevState.filter !== this.state.filter) {
+            $(ReactDOM.findDOMNode(this.refs.channelList)).scrollTop(0);
+        }
+    }
+
+>>>>>>> UCHAT-180 Paginate more channels modal to improve perf
     handleJoin(channel) {
         this.setState({joiningChannel: channel.id});
         this.props.handleJoin(
@@ -122,13 +131,18 @@ export default class MoreChannelsList extends React.Component {
     }
 
     render() {
+<<<<<<< HEAD
         const channels = Object.values(this.state.channels);
+=======
+        let channels = Object.values(this.state.channels);
+>>>>>>> UCHAT-180 Paginate more channels modal to improve perf
 
         let nextButton;
         let previousButton;
         let count;
 
         const startCount = this.state.page * this.props.channelsPerPage;
+<<<<<<< HEAD
         let endCount = startCount + this.props.channelsPerPage;
         if (this.props.total < endCount) {
             endCount = this.props.total;
@@ -136,6 +150,12 @@ export default class MoreChannelsList extends React.Component {
         const channelsToDisplay = channels.slice(startCount, endCount);
 
         if (endCount < this.props.total) {
+=======
+        const endCount = startCount + this.props.channelsPerPage;
+        const channelsToDisplay = channels.slice(startCount, endCount);
+
+        if (channelsToDisplay.length >= this.props.channelsPerPage) {
+>>>>>>> UCHAT-180 Paginate more channels modal to improve perf
             nextButton = (
                 <button
                     className='btn btn-default filter-control filter-control__next'
@@ -176,7 +196,11 @@ export default class MoreChannelsList extends React.Component {
         return (
             <div className='filtered-user-list'>
                 <div className='filter-row'>
+<<<<<<< HEAD
                     <div className='col-sm-12'>
+=======
+                    <div className='col-sm-6'>
+>>>>>>> UCHAT-180 Paginate more channels modal to improve perf
                         <input
                             ref='filter'
                             className='form-control filter-textbox'
@@ -186,7 +210,11 @@ export default class MoreChannelsList extends React.Component {
                         />
                     </div>
                     <div className='col-sm-12'>
+<<<<<<< HEAD
                         <span className='member-count pull-left'>{count}</span>
+=======
+                        <span className='channel-count pull-left'>{count}</span>
+>>>>>>> UCHAT-180 Paginate more channels modal to improve perf
                     </div>
                 </div>
                 <div
@@ -206,7 +234,11 @@ export default class MoreChannelsList extends React.Component {
 
 MoreChannelsList.defaultProps = {
     channels: [],
+<<<<<<< HEAD
     channelsPerPage: 50 //eslint-disable-line no-magic-numbers
+=======
+    channelsPerPage: 50, //eslint-disable-line no-magic-numbers
+>>>>>>> UCHAT-180 Paginate more channels modal to improve perf
 };
 
 MoreChannelsList.propTypes = {
@@ -215,5 +247,9 @@ MoreChannelsList.propTypes = {
     channelsPerPage: React.PropTypes.number,
     total: React.PropTypes.number,
     nextPage: React.PropTypes.func.isRequired,
+<<<<<<< HEAD
     search: React.PropTypes.func.isRequired
+=======
+    search: React.PropTypes.func.isRequired,
+>>>>>>> UCHAT-180 Paginate more channels modal to improve perf
 };

--- a/webapp/components/more_channels_list.jsx
+++ b/webapp/components/more_channels_list.jsx
@@ -199,7 +199,7 @@ export default class MoreChannelsList extends React.Component {
         return (
             <div
                 className='filtered-user-list'
-                style={{...this.props.style, 'max-height': `${height}px`}}
+                style={{'max-height': `${height}px`}}
             >
                 <div className='filter-row'>
                     <div className='col-sm-12'>

--- a/webapp/components/more_channels_list.jsx
+++ b/webapp/components/more_channels_list.jsx
@@ -68,15 +68,12 @@ export default class MoreChannelsList extends React.Component {
         this.setState({filter: '', channels});
     }
 
-<<<<<<< HEAD
-=======
     componentDidUpdate(prevProps, prevState) {
         if (prevState.filter !== this.state.filter) {
             $(ReactDOM.findDOMNode(this.refs.channelList)).scrollTop(0);
         }
     }
 
->>>>>>> UCHAT-180 Paginate more channels modal to improve perf
     handleJoin(channel) {
         this.setState({joiningChannel: channel.id});
         this.props.handleJoin(
@@ -131,18 +128,13 @@ export default class MoreChannelsList extends React.Component {
     }
 
     render() {
-<<<<<<< HEAD
         const channels = Object.values(this.state.channels);
-=======
-        let channels = Object.values(this.state.channels);
->>>>>>> UCHAT-180 Paginate more channels modal to improve perf
 
         let nextButton;
         let previousButton;
         let count;
 
         const startCount = this.state.page * this.props.channelsPerPage;
-<<<<<<< HEAD
         let endCount = startCount + this.props.channelsPerPage;
         if (this.props.total < endCount) {
             endCount = this.props.total;
@@ -150,12 +142,6 @@ export default class MoreChannelsList extends React.Component {
         const channelsToDisplay = channels.slice(startCount, endCount);
 
         if (endCount < this.props.total) {
-=======
-        const endCount = startCount + this.props.channelsPerPage;
-        const channelsToDisplay = channels.slice(startCount, endCount);
-
-        if (channelsToDisplay.length >= this.props.channelsPerPage) {
->>>>>>> UCHAT-180 Paginate more channels modal to improve perf
             nextButton = (
                 <button
                     className='btn btn-default filter-control filter-control__next'
@@ -196,11 +182,7 @@ export default class MoreChannelsList extends React.Component {
         return (
             <div className='filtered-user-list'>
                 <div className='filter-row'>
-<<<<<<< HEAD
                     <div className='col-sm-12'>
-=======
-                    <div className='col-sm-6'>
->>>>>>> UCHAT-180 Paginate more channels modal to improve perf
                         <input
                             ref='filter'
                             className='form-control filter-textbox'
@@ -210,11 +192,7 @@ export default class MoreChannelsList extends React.Component {
                         />
                     </div>
                     <div className='col-sm-12'>
-<<<<<<< HEAD
                         <span className='member-count pull-left'>{count}</span>
-=======
-                        <span className='channel-count pull-left'>{count}</span>
->>>>>>> UCHAT-180 Paginate more channels modal to improve perf
                     </div>
                 </div>
                 <div
@@ -234,11 +212,7 @@ export default class MoreChannelsList extends React.Component {
 
 MoreChannelsList.defaultProps = {
     channels: [],
-<<<<<<< HEAD
     channelsPerPage: 50 //eslint-disable-line no-magic-numbers
-=======
-    channelsPerPage: 50, //eslint-disable-line no-magic-numbers
->>>>>>> UCHAT-180 Paginate more channels modal to improve perf
 };
 
 MoreChannelsList.propTypes = {
@@ -247,9 +221,5 @@ MoreChannelsList.propTypes = {
     channelsPerPage: React.PropTypes.number,
     total: React.PropTypes.number,
     nextPage: React.PropTypes.func.isRequired,
-<<<<<<< HEAD
     search: React.PropTypes.func.isRequired
-=======
-    search: React.PropTypes.func.isRequired,
->>>>>>> UCHAT-180 Paginate more channels modal to improve perf
 };

--- a/webapp/components/more_channels_new.jsx
+++ b/webapp/components/more_channels_new.jsx
@@ -190,18 +190,6 @@ export default class MoreChannelsNew extends React.Component {
                         <div className='form-group has-error'><label className='control-label'>{this.state.serverError}</label></div>
                     }
                 </Modal.Body>
-                <Modal.Footer>
-                    <button
-                        type='button'
-                        className='btn btn-default'
-                        onClick={this.handleHide}
-                    >
-                        <FormattedMessage
-                            id='more_channels.close'
-                            defaultMessage='Close'
-                        />
-                    </button>
-                </Modal.Footer>
             </Modal>
         );
     }

--- a/webapp/components/more_channels_new.jsx
+++ b/webapp/components/more_channels_new.jsx
@@ -150,6 +150,7 @@ export default class MoreChannelsNew extends React.Component {
                     channelsPerPage={Constants.CHANNELS_CHUNK_SIZE}
                     handleJoin={this.handleJoin}
                     search={this.search}
+                    isSearch={this.state.search !== ''}
                     nextPage={this.nextPage}
                     total={ChannelStore.getPaginatedChannelsCount()}
                 />

--- a/webapp/components/more_direct_channels.jsx
+++ b/webapp/components/more_direct_channels.jsx
@@ -251,18 +251,6 @@ export default class MoreDirectChannels extends React.Component {
                         focusOnMount={!UserAgent.isMobile()}
                     />
                 </Modal.Body>
-                <Modal.Footer>
-                    <button
-                        type='button'
-                        className='btn btn-default'
-                        onClick={this.handleHide}
-                    >
-                        <FormattedMessage
-                            id='more_direct_channels.close'
-                            defaultMessage='Close'
-                        />
-                    </button>
-                </Modal.Footer>
             </Modal>
         );
     }

--- a/webapp/components/more_direct_channels.jsx
+++ b/webapp/components/more_direct_channels.jsx
@@ -244,6 +244,7 @@ export default class MoreDirectChannels extends React.Component {
                         key={'moreDirectChannelsList_' + this.state.listType}
                         users={this.state.users}
                         total={(this.state.users || []).length}
+                        hidePageCounts={true}
                         usersPerPage={USERS_PER_PAGE}
                         nextPage={this.nextPage}
                         search={this.search}

--- a/webapp/components/searchable_user_list.jsx
+++ b/webapp/components/searchable_user_list.jsx
@@ -135,7 +135,7 @@ export default class SearchableUserList extends React.Component {
                 nextButton = (
                     <div style={{'text-align': 'center'}}>
                         <SpinnerButton
-                            className='btn btn-warning filter-control filter-control__next'
+                            className='btn btn-default filter-control filter-control__next'
                             onClick={this.nextPage}
                             spinning={this.state.nextDisabled}
                         >

--- a/webapp/components/searchable_user_list.jsx
+++ b/webapp/components/searchable_user_list.jsx
@@ -2,6 +2,7 @@
 // See License.txt for license information.
 
 import UserList from 'components/user_list.jsx';
+import SpinnerButton from 'components/spinner_button.jsx';
 
 import * as Utils from 'utils/utils.jsx';
 import Constants from 'utils/constants.jsx';
@@ -19,7 +20,7 @@ export default class SearchableUserList extends React.Component {
         super(props);
 
         this.nextPage = this.nextPage.bind(this);
-        this.previousPage = this.previousPage.bind(this);
+        // this.previousPage = this.previousPage.bind(this);
         this.doSearch = this.doSearch.bind(this);
         this.onSearchBoxKeyPress = this.onSearchBoxKeyPress.bind(this);
         this.onSearchBoxChange = this.onSearchBoxChange.bind(this);
@@ -60,10 +61,12 @@ export default class SearchableUserList extends React.Component {
         this.props.nextPage(this.state.page + 1);
     }
 
+    /*
     previousPage(e) {
         e.preventDefault();
         this.setState({page: this.state.page - 1});
     }
+    */
 
     doSearch() {
         const term = this.refs.filter.value;
@@ -85,13 +88,12 @@ export default class SearchableUserList extends React.Component {
     onSearchBoxChange(e) {
         const searchTerm = e.target.value;
         if (searchTerm === '') {
-            this.props.search(''); // clear search
-            this.setState({page: 0, search: false});
+            this.doSearch();
         } else if (this.props.autoSearch === true) {
             clearTimeout(this.timeoutId);
             if (searchTerm && searchTerm.length >= 2) {
                 this.timeoutId = setTimeout(
-                    () => this.props.search(searchTerm),
+                    () => this.doSearch(),
                     Constants.AUTOCOMPLETE_TIMEOUT
                 );
             }
@@ -103,7 +105,6 @@ export default class SearchableUserList extends React.Component {
         // let previousButton;
         let usersToDisplay;
         let count;
-
         if (this.props.users == null) {
             usersToDisplay = this.props.users;
         } else if (this.state.search || this.props.users == null) {
@@ -133,14 +134,16 @@ export default class SearchableUserList extends React.Component {
             if (usersToDisplay.length >= this.props.usersPerPage) {
                 nextButton = (
                     <div style={{'text-align': 'center'}}>
-                        <button
+                        <SpinnerButton
                             className='btn btn-warning filter-control filter-control__next'
                             onClick={this.nextPage}
-                            disabled={this.state.nextDisabled}
-                            style={{width: '98%', margin: '1%', 'font-weight': 'bolder'}}
+                            spinning={this.state.nextDisabled}
                         >
-                            {'Next >>'}
-                        </button>
+                            <FormattedMessage
+                                id='more_direct_channels.load_more'
+                                defaultMessage='Load more'
+                            />
+                        </SpinnerButton>
                     </div>
                 );
             }

--- a/webapp/components/searchable_user_list.jsx
+++ b/webapp/components/searchable_user_list.jsx
@@ -185,7 +185,7 @@ export default class SearchableUserList extends React.Component {
         return (
             <div
                 className='filtered-user-list'
-                style={{...this.props.style, 'max-height': `${height}px`}}
+                style={{'max-height': `${height}px`}}
             >
                 <div className='filter-row'>
                     <div className='col-xs-12'>

--- a/webapp/components/searchable_user_list.jsx
+++ b/webapp/components/searchable_user_list.jsx
@@ -180,7 +180,7 @@ export default class SearchableUserList extends React.Component {
             }
         }
 
-        const height = $(window).height() - ($(window).width() <= 768 ? 100 : 170);
+        const height = $(window).height() - ($(window).width() <= 768 ? 120 : 170);
 
         return (
             <div

--- a/webapp/components/searchable_user_list.jsx
+++ b/webapp/components/searchable_user_list.jsx
@@ -94,7 +94,7 @@ export default class SearchableUserList extends React.Component {
         } else if (this.state.search || this.props.users == null) {
             usersToDisplay = this.props.users;
 
-            if (this.props.total) {
+            if (this.props.total && !this.props.hidePageCounts) {
                 count = (
                     <FormattedMessage
                         id='filtered_user_list.countTotal'
@@ -128,7 +128,7 @@ export default class SearchableUserList extends React.Component {
                 );
             }
 
-            if (this.props.total) {
+            if (this.props.total && !this.props.hidePageCounts) {
                 const startCount = this.state.page * this.props.usersPerPage;
                 const endCount = startCount + usersToDisplay.length;
 
@@ -197,6 +197,7 @@ SearchableUserList.propTypes = {
     users: React.PropTypes.arrayOf(React.PropTypes.object),
     usersPerPage: React.PropTypes.number,
     total: React.PropTypes.number,
+    hidePageCounts: React.PropTypes.bool,
     extraInfo: React.PropTypes.object,
     nextPage: React.PropTypes.func.isRequired,
     search: React.PropTypes.func.isRequired,

--- a/webapp/components/searchable_user_list.jsx
+++ b/webapp/components/searchable_user_list.jsx
@@ -20,7 +20,6 @@ export default class SearchableUserList extends React.Component {
         super(props);
 
         this.nextPage = this.nextPage.bind(this);
-        // this.previousPage = this.previousPage.bind(this);
         this.doSearch = this.doSearch.bind(this);
         this.onSearchBoxKeyPress = this.onSearchBoxKeyPress.bind(this);
         this.onSearchBoxChange = this.onSearchBoxChange.bind(this);
@@ -42,14 +41,6 @@ export default class SearchableUserList extends React.Component {
         }
     }
 
-    componentDidUpdate(prevProps, prevState) {
-        /*
-        if (this.state.page !== prevState.page) {
-            $(ReactDOM.findDOMNode(this.refs.userList)).scrollTop(0);
-        }
-        */
-    }
-
     componentWillUnmount() {
         clearTimeout(this.nextTimeoutId);
     }
@@ -60,13 +51,6 @@ export default class SearchableUserList extends React.Component {
         this.nextTimeoutId = setTimeout(() => this.setState({nextDisabled: false}), NEXT_BUTTON_TIMEOUT);
         this.props.nextPage(this.state.page + 1);
     }
-
-    /*
-    previousPage(e) {
-        e.preventDefault();
-        this.setState({page: this.state.page - 1});
-    }
-    */
 
     doSearch() {
         const term = this.refs.filter.value;
@@ -103,7 +87,6 @@ export default class SearchableUserList extends React.Component {
 
     render() {
         let nextButton;
-        // let previousButton;
         let usersToDisplay;
         let count;
         if (this.props.users == null) {
@@ -124,10 +107,6 @@ export default class SearchableUserList extends React.Component {
                 );
             }
         } else {
-            /*const pageStart = this.state.page * this.props.usersPerPage;
-            const pageEnd = pageStart + this.props.usersPerPage;
-            usersToDisplay = this.props.users.slice(pageStart, pageEnd);
-            */
             const pageStart = 0;
             const pageEnd = (this.state.page + 1) * this.props.usersPerPage;
             usersToDisplay = this.props.users.slice(pageStart, pageEnd);
@@ -148,18 +127,6 @@ export default class SearchableUserList extends React.Component {
                     </div>
                 );
             }
-            /*
-            if (this.state.page > 0) {
-                previousButton = (
-                    <button
-                        className='btn btn-default filter-control filter-control__prev'
-                        onClick={this.previousPage}
-                    >
-                        {'Previous'}
-                    </button>
-                );
-            }
-            */
 
             if (this.props.total) {
                 const startCount = this.state.page * this.props.usersPerPage;
@@ -180,13 +147,8 @@ export default class SearchableUserList extends React.Component {
             }
         }
 
-        const height = $(window).height() - ($(window).width() <= 768 ? 120 : 170);
-
         return (
-            <div
-                className='filtered-user-list'
-                style={{'max-height': `${height}px`}}
-            >
+            <div className='filtered-user-list'>
                 <div className='filter-row'>
                     <div className='col-xs-12'>
                         <input

--- a/webapp/components/searchable_user_list.jsx
+++ b/webapp/components/searchable_user_list.jsx
@@ -42,9 +42,11 @@ export default class SearchableUserList extends React.Component {
     }
 
     componentDidUpdate(prevProps, prevState) {
+        /*
         if (this.state.page !== prevState.page) {
             $(ReactDOM.findDOMNode(this.refs.userList)).scrollTop(0);
         }
+        */
     }
 
     componentWillUnmount() {
@@ -98,7 +100,7 @@ export default class SearchableUserList extends React.Component {
 
     render() {
         let nextButton;
-        let previousButton;
+        // let previousButton;
         let usersToDisplay;
         let count;
 
@@ -120,22 +122,29 @@ export default class SearchableUserList extends React.Component {
                 );
             }
         } else {
-            const pageStart = this.state.page * this.props.usersPerPage;
+            /*const pageStart = this.state.page * this.props.usersPerPage;
             const pageEnd = pageStart + this.props.usersPerPage;
+            usersToDisplay = this.props.users.slice(pageStart, pageEnd);
+            */
+            const pageStart = 0;
+            const pageEnd = (this.state.page + 1) * this.props.usersPerPage;
             usersToDisplay = this.props.users.slice(pageStart, pageEnd);
 
             if (usersToDisplay.length >= this.props.usersPerPage) {
                 nextButton = (
-                    <button
-                        className='btn btn-default filter-control filter-control__next'
-                        onClick={this.nextPage}
-                        disabled={this.state.nextDisabled}
-                    >
-                        {'Next'}
-                    </button>
+                    <div style={{'text-align': 'center'}}>
+                        <button
+                            className='btn btn-warning filter-control filter-control__next'
+                            onClick={this.nextPage}
+                            disabled={this.state.nextDisabled}
+                            style={{width: '98%', margin: '1%', 'font-weight': 'bolder'}}
+                        >
+                            {'Next >>'}
+                        </button>
+                    </div>
                 );
             }
-
+            /*
             if (this.state.page > 0) {
                 previousButton = (
                     <button
@@ -146,6 +155,7 @@ export default class SearchableUserList extends React.Component {
                     </button>
                 );
             }
+            */
 
             if (this.props.total) {
                 const startCount = this.state.page * this.props.usersPerPage;
@@ -166,8 +176,13 @@ export default class SearchableUserList extends React.Component {
             }
         }
 
+        const height = $(window).height() - ($(window).width() <= 768 ? 100 : 170);
+
         return (
-            <div className='filtered-user-list'>
+            <div
+                className='filtered-user-list'
+                style={{...this.props.style, 'max-height': `${height}px`}}
+            >
                 <div className='filter-row'>
                     <div className='col-xs-12'>
                         <input
@@ -193,9 +208,6 @@ export default class SearchableUserList extends React.Component {
                         actionProps={this.props.actionProps}
                         actionUserProps={this.props.actionUserProps}
                     />
-                </div>
-                <div className='filter-controls'>
-                    {previousButton}
                     {nextButton}
                 </div>
             </div>

--- a/webapp/components/searchable_user_list.jsx
+++ b/webapp/components/searchable_user_list.jsx
@@ -76,6 +76,7 @@ export default class SearchableUserList extends React.Component {
         } else {
             this.setState({search: true});
         }
+        $(ReactDOM.findDOMNode(this.refs.userList)).scrollTop(0);
     }
 
     onSearchBoxKeyPress(e) {

--- a/webapp/components/team_members_modal.jsx
+++ b/webapp/components/team_members_modal.jsx
@@ -68,18 +68,6 @@ export default class TeamMembersModal extends React.Component {
                         isAdmin={this.props.isAdmin}
                     />
                 </Modal.Body>
-                <Modal.Footer>
-                    <button
-                        type='button'
-                        className='btn btn-default'
-                        onClick={this.onHide}
-                    >
-                        <FormattedMessage
-                            id='team_member_modal.close'
-                            defaultMessage='Close'
-                        />
-                    </button>
-                </Modal.Footer>
             </Modal>
         );
     }

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -1506,6 +1506,7 @@
   "more_channels.createClick": "Click 'Create New Channel' to make a new one",
   "more_channels.join": "Join",
   "more_channels.noMore": "No more channels to join",
+  "more_channels.noChannelsFound": "No channels found",
   "more_channels.title": "More Channels",
   "more_direct_channels.close": "Close",
   "more_direct_channels.message": "Message",

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -1509,6 +1509,7 @@
   "more_channels.title": "More Channels",
   "more_direct_channels.close": "Close",
   "more_direct_channels.message": "Message",
+  "more_direct_channels.load_more": "Load more",
   "more_direct_channels.title": "Direct Messages",
   "msg_typing.areTyping": "{users} and {last} are typing...",
   "msg_typing.isTyping": "{user} is typing...",

--- a/webapp/i18n/es.json
+++ b/webapp/i18n/es.json
@@ -1503,6 +1503,7 @@
   "more_channels.createClick": "Haz clic en 'Crear Nuevo Canal' para crear uno nuevo",
   "more_channels.join": "Unirme",
   "more_channels.noMore": "No hay más canales para unirse",
+  "more_channels.noChannelsFound": "No se encontraron canales",
   "more_channels.title": "Más Canales",
   "more_direct_channels.close": "Cerrar",
   "more_direct_channels.message": "Mensaje",

--- a/webapp/i18n/es.json
+++ b/webapp/i18n/es.json
@@ -1506,6 +1506,7 @@
   "more_channels.title": "Más Canales",
   "more_direct_channels.close": "Cerrar",
   "more_direct_channels.message": "Mensaje",
+  "more_direct_channels.load_more": "Mostrar más",
   "more_direct_channels.title": "Mensajes Directos",
   "msg_typing.areTyping": "{users} y {last} están escribiendo...",
   "msg_typing.isTyping": "{user} está escribiendo...",

--- a/webapp/i18n/fr.json
+++ b/webapp/i18n/fr.json
@@ -1506,6 +1506,7 @@
   "more_channels.title": "Plus de canaux",
   "more_direct_channels.close": "Fermer",
   "more_direct_channels.message": "Message",
+  "more_direct_channels.load_more": "Montrer plus",
   "more_direct_channels.title": "Messages privés",
   "msg_typing.areTyping": "{users} et {last} sont en train d'écrire...",
   "msg_typing.isTyping": "{user} est en train d'écrire...",

--- a/webapp/i18n/fr.json
+++ b/webapp/i18n/fr.json
@@ -1503,6 +1503,7 @@
   "more_channels.createClick": "Cliquez sur \"Créer un nouveau canal\" pour en créer un",
   "more_channels.join": "Rejoindre",
   "more_channels.noMore": "Plus de canal à rejoindre",
+  "more_channels.noChannelsFound": "Aucun de canal trouvé",
   "more_channels.title": "Plus de canaux",
   "more_direct_channels.close": "Fermer",
   "more_direct_channels.message": "Message",

--- a/webapp/sass/components/_modal.scss
+++ b/webapp/sass/components/_modal.scss
@@ -11,8 +11,7 @@
     }
 
     .modal-body {
-        max-height: calc(90vh - 62px);
-        overflow: auto;
+        overflow: hidden;
         padding: 20px 15px;
     }
 
@@ -237,6 +236,19 @@
             left: 0;
             position: absolute;
             top: 0;
+        }
+
+        &.more-channel__modal {
+            .modal-body {
+                overflow-x: hidden;
+                padding: 10px 0 0;
+            }
+
+            .channel-count {
+                @include opacity(.8);
+                float: right;
+                margin-top: 5px;
+            }
         }
 
         .modal-image {

--- a/webapp/sass/components/_modal.scss
+++ b/webapp/sass/components/_modal.scss
@@ -560,6 +560,15 @@
     flex-direction: column;
     overflow: auto;
 
+    .filter-control__next {
+        font-weight: bolder;
+        margin: 1%;
+        margin-right: 15px;
+        background-color: transparent;
+        border-color: transparent;
+        width: 90%;
+    }
+
     .popover & {
         font-size: .95em;
 

--- a/webapp/sass/responsive/_mobile.scss
+++ b/webapp/sass/responsive/_mobile.scss
@@ -9,9 +9,17 @@
     }
 
     .filtered-user-list {
-        .filter-button {
-            .btn {
-                width: 100%;
+        .filter-row {
+            margin: 5px 0;
+            .filter-text {
+                padding: 0 0 0 15px;
+            }
+
+            .filter-button {
+                padding: 0 15px 0 0;
+                .btn {
+                    text-align: center;
+                }
             }
         }
     }
@@ -134,8 +142,8 @@
     }
 
     .member-select__container {
-        margin-bottom: 10px;
-        margin-top: 10px;
+        margin-bottom: 5px;
+        margin-top: 5px;
         overflow: hidden;
         position: relative;
         right: 10px;
@@ -523,6 +531,8 @@
             }
 
             .modal-header {
+                padding: 4px 15px 1px;
+                min-height: 36px;
                 .modal-action {
                     margin-top: 10px;
                 }
@@ -546,6 +556,11 @@
                         width: 100%;
                     }
                 }
+            }
+
+            .modal-footer {
+                padding: 5px;
+                background: whitesmoke;
             }
 
             .settings-modal {

--- a/webapp/sass/responsive/_mobile.scss
+++ b/webapp/sass/responsive/_mobile.scss
@@ -1327,21 +1327,16 @@
             }
 
             .more-modal__list {
-                max-height: calc(100vh - 306px);
+                max-height: calc(100vh - 200px);
             }
             &.more-direct-channels {
                 .more-modal__list {
-                    max-height: calc(100vh - 316px);
+                    max-height: calc(100vh - 200px);
                 }
             }
-            &.list-members {
+            &.list-members, &.no-team-filter, &.no-new-channel-btn {
                 .more-modal__list {
-                    max-height: calc(100vh - 265px);
-                }
-            }
-            &.no-team-filter, &.no-new-channel-btn {
-                .more-modal__list {
-                    max-height: calc(100vh - 260px);
+                    max-height: calc(100vh - 155px);
                 }
             }
         }

--- a/webapp/sass/responsive/_mobile.scss
+++ b/webapp/sass/responsive/_mobile.scss
@@ -531,8 +531,6 @@
             }
 
             .modal-header {
-                padding: 4px 15px 1px;
-                min-height: 36px;
                 .modal-action {
                     margin-top: 10px;
                 }
@@ -1357,7 +1355,6 @@
                 .modal-body {
                     padding-bottom: 35px;
                 }
-
             }
 
             .settings-modal {


### PR DESCRIPTION
Ticket: https://jira.uberinternal.com/browse/UCHAT-202

- Changed it to 'Load more' button centered with spinner on click.
- Added channel count to be able to know when to hide load more button.
- Logic added to Channels modal, Direct Message modal, View Members, Add Members.
- Removed bottom 'Close' buttons in modals 
- Display message when 'No Channels Found' when searching
--------------------------
Move "Next" button in channel lists
In channel lists, e.g. Manage/View Members modal and "More..." list in direct message channels, move "Next" button to the bottom of the user list
P2: On mobile, show a scrollbar when the list appears, not only once you start scrolling (this already happens on the browser)
NOTE:
This was work previously done for MM but never merged:
https://github.com/csduarte/platform/compare/master...fullstacklabs:PLT-4629?expand=1 
MM ticket: https://mattermost.atlassian.net/browse/PLT-4557

Previous screens:
![uchat-direct-modal-current- iphone 6 plus](https://cloud.githubusercontent.com/assets/160621/20784598/53bc4e48-b769-11e6-8f37-49c7be5f6eed.png)
![uchat-direct-modal-current](https://cloud.githubusercontent.com/assets/160621/20784589/48dbca4e-b769-11e6-998c-4b87a2b92854.png)

New screens:
![uchat-direct-modal-new-mobile](https://cloud.githubusercontent.com/assets/160621/20784729/24b466b6-b76a-11e6-8e16-056322015023.png)
![uchat-direct-modal-new-1](https://cloud.githubusercontent.com/assets/160621/20784771/54d6940e-b76a-11e6-9846-c226aaa5941e.png)

![uchat-channelsmodal-nochannelsfound](https://cloud.githubusercontent.com/assets/23249245/21036894/2926b46e-bd97-11e6-8a8d-59c6284f0041.png)

