### PR TITLE
UCHAT-186 set a min-height for the sidebar menu header

### DIFF
--- a/webapp/sass/layout/_headers.scss
+++ b/webapp/sass/layout/_headers.scss
@@ -320,9 +320,13 @@
 
         .header__info {
             @include clearfix;
+            @include display-flex;
+            @include flex-direction(column);
+            @include justify-content(center);
             color: $white;
             padding-left: 2px;
             position: relative;
+            min-height: 38px;
             z-index: 1;
         }
 


### PR DESCRIPTION
When the user does not have a first name nor last name, then header menu would appear misaligned as such:
<img width="222" alt="screen shot 2016-11-23 at 8 33 48 am" src="https://cloud.githubusercontent.com/assets/910657/20819651/aaf33808-b7ea-11e6-90b5-ff7d8b940151.png">

This should only happen during dev, as we expect our users to have a proper first name and last name.

This PR addresses this misalignment issue by using flexboxes to justify the contents in the green header to center, and set a min-height for the header.

Results:
<img width="220" alt="screen shot 2016-12-01 at 4 49 18 pm" src="https://cloud.githubusercontent.com/assets/910657/20819660/cb6494f6-b7ea-11e6-8065-ff4306a17124.png">
<img width="220" alt="screen shot 2016-12-01 at 4 48 58 pm" src="https://cloud.githubusercontent.com/assets/910657/20819666/cf888a42-b7ea-11e6-8ae4-f097a6a6a1e4.png">
<img width="220" alt="screen shot 2016-12-01 at 5 24 06 pm" src="https://cloud.githubusercontent.com/assets/910657/20819700/04910dc2-b7eb-11e6-8822-800bb02f65ac.png">

