### PR TITLE
UCHAT-36 Invalidate user channel members cache when creating a new channel

### DIFF
--- a/api/channel.go
+++ b/api/channel.go
@@ -116,6 +116,8 @@ func CreateChannel(c *Context, channel *model.Channel, addMember bool) (*model.C
 			if cmresult := <-Srv.Store.Channel().SaveMember(cm); cmresult.Err != nil {
 				return nil, cmresult.Err
 			}
+
+			InvalidateCacheForUser(c.Session.UserId)
 		}
 
 		c.LogAudit("name=" + channel.Name)


### PR DESCRIPTION
This should fix the permissions error that was intermittently encountered when creating a new DM/channel.
https://github.com/mattermost/platform/pull/4694
https://mattermost.atlassian.net/browse/PLT-4750