### PR TITLE
UCHAT-216 append -archived-timestamp to channel name before deleting the channel

### DIFF
--- a/api/channel.go
+++ b/api/channel.go
@@ -6,6 +6,7 @@ package api
 import (
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 
 	l4g "github.com/alecthomas/log4go"
@@ -773,6 +774,16 @@ func deleteChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		}
 
 		now := model.GetMillis()
+
+		// Update channel name to contain "-archived" + timestamp
+		currentTimeStr := strconv.FormatInt(now, 10)
+		channel.Name += "-archived-" + currentTimeStr
+		channel.DisplayName += "-archived-" + currentTimeStr
+		if ucresult := <-Srv.Store.Channel().Update(channel); ucresult.Err != nil {
+			c.Err = ucresult.Err
+			return
+		}
+
 		for _, hook := range incomingHooks {
 			go func() {
 				if result := <-Srv.Store.Webhook().DeleteIncoming(hook.Id, now); result.Err != nil {

--- a/api/channel_test.go
+++ b/api/channel_test.go
@@ -970,6 +970,19 @@ func TestDeleteChannel(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Check if deleted channel name is changed to contain "-archived-"
+	if resp, err := Client.GetChannel(channel1.Id, ""); err != nil {
+		t.Fatal(err)
+	} else {
+		data := resp.Data.(*model.ChannelData)
+		if !strings.Contains(data.Channel.DisplayName, "-archived-") {
+			t.Fatal("deleted channel DisplayName did not contain -archived-")
+		}
+		if !strings.Contains(data.Channel.Name, "-archived-") {
+			t.Fatal("deleted channel Name did not contain -archived-")
+		}
+	}
+
 	if _, err := Client.DeleteChannel(channelMadeByCA.Id); err != nil {
 		t.Fatal("Team admin failed to delete Channel Admin's channel")
 	}


### PR DESCRIPTION
- Add a step in `deleteChannel` function to append `-archived-<timestamp>` to the end of `DisplayName` and `Name` of the channel
- Modified unit test to test for the changes in name strings

Verified manually with public and private channels:

Id | CreateAt | UpdateAt | DeleteAt | TeamId | Type | DisplayName | Name | Header | Purpose | LastPostAt | TotalMsgCount | ExtraUpdateAt | CreatorId
--- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | ---
5du7ojitafd68rg6ccwjqyeypa | 1480712298929 | 1480712306455 | 1480712306455 | 3er5yfpuafne9m5sp7tb84g6xo | P | ptest-archived-1480712306429 | ptest-archived-1480712306429 |  |  | 0 | 0 | 1480712298975 | 73ajmzk81pyxxjwah5tfkcxxze
hjsif8bwb385pygzprgk89xj5a | 1480708375285 | 1480708379124 | 1480708379124 | 3er5yfpuafne9m5sp7tb84g6xo | O | test4-archived-1480708379100 | test4-archived-1480708379100 |  |  | 0 | 0 | 1480708375330 | 73ajmzk81pyxxjwah5tfkcxxze

Ran tests:
```
=== RUN   TestDeleteChannel
[2016/12/02 13:32:20 PST] [DEBG] /api/v3/users/login
[2016/12/02 13:32:21 PST] [DEBG] /api/v3/teams/wnw8osaqjpf8uxku6cmcwoz3ne/channels/create
[2016/12/02 13:32:21 PST] [DEBG] /api/v3/teams/wnw8osaqjpf8uxku6cmcwoz3ne/channels/7jux9uig9jyi8rmiqybxjxydwy/add
[2016/12/02 13:32:21 PST] [DEBG] /api/v3/users/login
[2016/12/02 13:32:21 PST] [DEBG] Sending push notification to  with msg of 'System mentioned you in C Test API Name'
... snip ...
--- PASS: TestDeleteChannel (11.75s)
```