### PR TITLE
UCHAT-196 add filename display to file upload preview for non-images

### DIFF
--- a/webapp/components/file_preview.jsx
+++ b/webapp/components/file_preview.jsx
@@ -33,6 +33,7 @@ export default class FilePreview extends React.Component {
 
             let className = 'file-preview';
             let previewImage;
+            let fileName;
             if (type === 'image') {
                 previewImage = (
                     <img
@@ -43,6 +44,7 @@ export default class FilePreview extends React.Component {
             } else {
                 className += ' custom-file';
                 previewImage = <div className={'file-icon ' + Utils.getIconClassName(type)}/>;
+                fileName = <div className='file-preview__name'>{info.name}</div>;
             }
 
             previews.push(
@@ -51,6 +53,7 @@ export default class FilePreview extends React.Component {
                     className={className}
                 >
                     {previewImage}
+                    {fileName}
                     <a
                         className='file-preview__remove'
                         onClick={this.handleRemove.bind(this, info.id)}

--- a/webapp/sass/components/_files.scss
+++ b/webapp/sass/components/_files.scss
@@ -49,6 +49,17 @@
     max-width: 100%;
 }
 
+.file-preview__name {
+    background: alpha-color($black, .4);
+    color: $white;
+    top: 0;
+    width: 120px;
+    position: absolute;
+    word-wrap: break-word;
+    white-space: normal;
+    padding: 5px 20px 10px 10px;
+}
+
 .file-preview__remove {
     height: 100%;
     left: 0;

--- a/webapp/sass/responsive/_mobile.scss
+++ b/webapp/sass/responsive/_mobile.scss
@@ -681,6 +681,10 @@
         margin-top: 0;
     }
 
+    .file-preview__name {
+        padding: 5px 30px 10px 10px;
+    }
+
     .file-preview__remove {
         @include alpha-property(background, $black, .5);
         height: 28px;


### PR DESCRIPTION
- Added a filename display overlay on top of file preview for non-image files:

desktop:
<img width="667" alt="screen shot 2016-12-02 at 3 13 14 pm" src="https://cloud.githubusercontent.com/assets/910657/20853875/0d9249f4-b8a4-11e6-9b01-6d3829c88373.png">
mobile:
<img width="361" alt="screen shot 2016-12-02 at 3 13 40 pm" src="https://cloud.githubusercontent.com/assets/910657/20853889/1fa7d9b0-b8a4-11e6-938b-86f3a43ae169.png">