### PR TITLE
UCHAT-227 allow single enter key to switch channels in channel switcher

### DIFF
--- a/webapp/components/channel_switch_modal.jsx
+++ b/webapp/components/channel_switch_modal.jsx
@@ -72,17 +72,22 @@ export default class SwitchChannelModal extends React.Component {
         this.setState({text: e.target.value});
     }
 
-    handleKeyDown(e) {
-        this.setState({
+    handleKeyDown(e, selectionText) {
+        const newState = {
             error: ''
-        });
+        };
+        if (selectionText) {
+            newState.text = selectionText;
+        }
+        this.setState(newState);
+
         if (e.keyCode === Constants.KeyCodes.ENTER) {
-            this.handleSubmit();
+            this.handleSubmit(selectionText);
         }
     }
 
-    handleSubmit() {
-        const name = this.state.text.trim();
+    handleSubmit(selectionText) {
+        const name = selectionText || this.state.text.trim();
         let channel = null;
 
         // TODO: Replace this hack with something reasonable
@@ -95,25 +100,25 @@ export default class SwitchChannelModal extends React.Component {
                     user,
                     (ch) => {
                         channel = ch;
-                        this.switchToChannel(channel);
+                        this.switchToChannel(channel, name);
                     },
                     () => {
                         channel = null;
-                        this.switchToChannel(channel);
+                        this.switchToChannel(channel, name);
                     }
                 );
             }
         } else {
-            channel = ChannelStore.getByName(this.state.text.trim());
-            this.switchToChannel(channel);
+            channel = ChannelStore.getByName(name);
+            this.switchToChannel(channel, name);
         }
     }
 
-    switchToChannel(channel) {
+    switchToChannel(channel, name) {
         if (channel !== null) {
             goToChannel(channel);
             this.onHide();
-        } else if (this.state.text !== '') {
+        } else if (name !== '') {
             this.setState({
                 error: Utils.localizeMessage('channel_switch_modal.not_found', 'No matches found.')
             });
@@ -155,6 +160,7 @@ export default class SwitchChannelModal extends React.Component {
                         onChange={this.onChange}
                         value={this.state.text}
                         onKeyDown={this.handleKeyDown}
+                        overrideEnterKey={true}
                         listComponent={SuggestionList}
                         maxLength='64'
                         providers={this.suggestionProviders}

--- a/webapp/components/suggestion/suggestion_box.jsx
+++ b/webapp/components/suggestion/suggestion_box.jsx
@@ -138,6 +138,8 @@ export default class SuggestionBox extends React.Component {
             } else if (e.which === KeyCodes.DOWN) {
                 GlobalActions.emitSelectNextSuggestion(this.suggestionId);
                 e.preventDefault();
+            } else if (this.props.overrideEnterKey && this.props.onKeyDown && e.which === KeyCodes.ENTER) {
+                this.props.onKeyDown(e, SuggestionStore.getSelection(this.suggestionId));
             } else if (e.which === KeyCodes.ENTER || e.which === KeyCodes.TAB) {
                 GlobalActions.emitCompleteWordSuggestion(this.suggestionId);
                 e.preventDefault();
@@ -242,6 +244,7 @@ SuggestionBox.propTypes = {
     providers: React.PropTypes.arrayOf(React.PropTypes.object),
     listStyle: React.PropTypes.string,
     renderDividers: React.PropTypes.bool,
+    overrideEnterKey: React.PropTypes.bool,
 
     // explicitly name any input event handlers we override and need to manually call
     onChange: React.PropTypes.func,


### PR DESCRIPTION
- Add optional property `overrideEnterKey` to `SuggestionBox` component to allow overriding default enter key handling (default autocompletes)
- Use `overrideEnterKey` in `SwitchChannelModal` component to allow switching channels using enter key directly on the suggestions list

Demo gif:
![switch-channel](https://cloud.githubusercontent.com/assets/910657/20901866/6db5263e-bae9-11e6-85f3-b5e25325cdff.gif)
