### PR TITLE
UCHAT-169 fix hover issue with reply menu for one line messages

### DIFF
--- a/webapp/sass/layout/_post.scss
+++ b/webapp/sass/layout/_post.scss
@@ -471,6 +471,12 @@
         .permalink-icon {
             visibility: visible;
         }
+
+        .post__header {
+            .col__reply {
+                display: inline-block;
+            }
+        }
     }
 
     &.post--hovered {
@@ -480,6 +486,12 @@
         .post__remove,
         .permalink-icon {
             visibility: visible;
+        }
+
+        .post__header {
+            .col__reply {
+                display: inline-block;
+            }
         }
 
         .post__body {
@@ -812,6 +824,7 @@
         }
 
         .col__reply {
+            display: none;
             border: 1px solid transparent;
             border-radius: 2px;
             min-width: 70px;


### PR DESCRIPTION
There's some oddities with the reply menu currently if the user hovers over a one line message:
![before](https://cloud.githubusercontent.com/assets/910657/20903832/cca126c2-baf1-11e6-9eca-40096446129f.gif)

This PR addresses the issue by toggling between `display: none;` and `display: inline-block;` for that particular menu.
Demo:
![after](https://cloud.githubusercontent.com/assets/910657/20903861/f03fbcec-baf1-11e6-9bcd-be53cf6486b4.gif)
