### PR TITLE
UCHAT-73 focus search input when Add members modal gets displayed

### DIFF
--- a/webapp/components/channel_invite_modal.jsx
+++ b/webapp/components/channel_invite_modal.jsx
@@ -12,6 +12,7 @@ import TeamStore from 'stores/team_store.jsx';
 import {searchUsers} from 'actions/user_actions.jsx';
 
 import * as AsyncClient from 'utils/async_client.jsx';
+import * as UserAgent from 'utils/user_agent.jsx';
 
 import React from 'react';
 import {Modal} from 'react-bootstrap';
@@ -144,6 +145,7 @@ export default class ChannelInviteModal extends React.Component {
                         channel: this.props.channel,
                         onInviteError: this.handleInviteError
                     }}
+                    focusOnMount={!UserAgent.isMobile()}
                 />
             );
         }

--- a/webapp/components/searchable_user_list.jsx
+++ b/webapp/components/searchable_user_list.jsx
@@ -35,7 +35,9 @@ export default class SearchableUserList extends React.Component {
 
     componentDidMount() {
         if (this.props.focusOnMount) {
-            this.refs.filter.focus();
+            setTimeout(() => {
+                this.refs.filter.focus();
+            });
         }
     }
 


### PR DESCRIPTION
- Add missing property in `channel_invite_modal` component to focus search input upon creation
- Fix async timing issue causing focus to not be set when transitioning from "View Members" to "Add New Members to <channel-name>" using the "Add New Members" button. 

Before Demo:
![before](https://cloud.githubusercontent.com/assets/910657/20905849/67ee1038-bafa-11e6-80c3-dcef3d88ee42.gif)

After Demo:
![add](https://cloud.githubusercontent.com/assets/910657/20905765/055063ea-bafa-11e6-844b-7b1757d06ff6.gif)
