### PR TITLE
UCHAT-151 modify the image attachment preview to match design

### DIFF
--- a/webapp/components/file_attachment.jsx
+++ b/webapp/components/file_attachment.jsx
@@ -9,6 +9,8 @@ import {Tooltip, OverlayTrigger} from 'react-bootstrap';
 
 import React from 'react';
 
+import downloadIcon from 'images/download_CTA.svg';
+
 export default class FileAttachment extends React.Component {
     constructor(props) {
         super(props);
@@ -63,31 +65,11 @@ export default class FileAttachment extends React.Component {
         const fileInfo = this.props.fileInfo;
         const fileName = fileInfo.name;
         const fileUrl = FileStore.getFileUrl(fileInfo.id);
+        const fileType = Utils.getFileType(fileInfo.extension);
 
         let thumbnail;
         if (this.state.loaded) {
-            const type = Utils.getFileType(fileInfo.extension);
-
-            if (type === 'image') {
-                let className = 'post-image';
-
-                if (fileInfo.width < Constants.THUMBNAIL_WIDTH && fileInfo.height < Constants.THUMBNAIL_HEIGHT) {
-                    className += ' small';
-                } else {
-                    className += ' normal';
-                }
-
-                thumbnail = (
-                    <div
-                        className={className}
-                        style={{
-                            backgroundImage: `url(${FileStore.getFileThumbnailUrl(fileInfo.id)})`
-                        }}
-                    />
-                );
-            } else {
-                thumbnail = <div className={'file-icon ' + Utils.getIconClassName(type)}/>;
-            }
+            thumbnail = <div className={'file-icon ' + Utils.getIconClassName(fileType)}/>;
         } else {
             thumbnail = <div className='post-image__load'/>;
         }
@@ -157,18 +139,20 @@ export default class FileAttachment extends React.Component {
             );
         }
 
-        return (
-            <div className='post-image__column'>
-                <a
-                    className='post-image__thumbnail'
-                    href='#'
-                    onClick={this.onAttachmentClick}
-                >
-                    {thumbnail}
-                </a>
-                <div className='post-image__details'>
-                    {filenameOverlay}
-                    <div>
+        let fileAttachment;
+        if (fileType === 'image' && !this.props.compactDisplay) {
+            fileAttachment = (
+                <div className='post-image__preview'>
+                    <a
+                        href='#'
+                        onClick={this.onAttachmentClick}
+                    >
+                        <img
+                            className='post-image__image'
+                            src={FileStore.getFileThumbnailUrl(fileInfo.id)}
+                        />
+                    </a>
+                    <div className='post-image__info'>
                         <a
                             href={fileUrl}
                             download={fileName}
@@ -176,12 +160,45 @@ export default class FileAttachment extends React.Component {
                             target='_blank'
                             rel='noopener noreferrer'
                         >
-                            <span className='fa fa-download'/>
+                            <img src={downloadIcon}/>
+                            {filenameOverlay}
+                            <span className='post-image__size'>{Utils.fileSizeToString(fileInfo.size)}</span>
                         </a>
-                        <span className='post-image__type'>{fileInfo.extension.toUpperCase()}</span>
-                        <span className='post-image__size'>{Utils.fileSizeToString(fileInfo.size)}</span>
                     </div>
                 </div>
+            );
+        } else {
+            fileAttachment = (
+                <div className='post-image__column'>
+                    <a
+                        className='post-image__thumbnail'
+                        href='#'
+                        onClick={this.onAttachmentClick}
+                    >
+                        {thumbnail}
+                    </a>
+                    <div className='post-image__details'>
+                        {filenameOverlay}
+                        <div>
+                            <a
+                                href={fileUrl}
+                                download={fileName}
+                                className='post-image__download'
+                                target='_blank'
+                                rel='noopener noreferrer'
+                            >
+                                <span className='fa fa-download'/>
+                            </a>
+                            <span className='post-image__type'>{fileInfo.extension.toUpperCase()}</span>
+                            <span className='post-image__size'>{Utils.fileSizeToString(fileInfo.size)}</span>
+                        </div>
+                    </div>
+                </div>
+            );
+        }
+        return (
+            <div>
+                {fileAttachment}
             </div>
         );
     }

--- a/webapp/images/download_CTA.svg
+++ b/webapp/images/download_CTA.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="20px" height="20px" viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 41.2 (35397) - http://www.bohemiancoding.com/sketch -->
+    <title>Group 4</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Message-Thread:-File" transform="translate(-862.000000, -378.000000)">
+            <g id="Group-4-Copy" transform="translate(651.000000, 307.000000)">
+                <g id="Group-4" transform="translate(211.000000, 71.000000)">
+                    <circle id="Oval" fill="#000000" cx="10" cy="10" r="10"></circle>
+                    <path d="M14.75,15 L5.25,15 C5.1118164,15 5,14.8881836 5,14.75 L5,13.25 C5,13.1119385 5.1118164,13 5.25,13 L14.75,13 C14.8881836,13 15,13.1119385 15,13.25 L15,14.75 C15,14.8881836 14.8881836,15 14.75,15 Z M12,8.11986512 L12,5 L8,5 L8,8.11986512 L6,8.11986512 L9.39345313,11.7590966 C9.69296502,12.0803011 10.3070345,12.0803011 10.6065474,11.7590966 L14,8.11986512 L12,8.11986512 Z" id="Shape" fill="#FFFFFF"></path>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/webapp/sass/components/_files.scss
+++ b/webapp/sass/components/_files.scss
@@ -180,52 +180,37 @@
     width: 100%;
 }
 
-.post-image {
-    background-color: $white;
-    background-repeat: no-repeat;
-    height: 100%;
-    overflow: hidden;
-    position: relative;
-    text-align: center;
-    width: 100%;
-
-    &.small {
-        background-position: center;
-    }
-
-    &.normal {
-        background-position: top left;
-    }
-
-    .spinner {
-        .file__loading {
-            left: 50%;
-            margin-left: -16px;
-            margin-top: -16px;
-            position: absolute;
-            top: 50%;
-        }
-    }
-
-    .file__loaded {
-        max-width: initial;
-
-        &.landscape,
-        &.quadrat {
-            height: 100px;
-        }
-
-        &.portrait {
-            width: 120px;
-        }
-    }
-}
-
 .post-image__thumbnail {
     @include cursor(zoom-in);
+    color: alpha-color($black, .8);
     float: left;
     height: 100%;
     width: 50%;
+}
+
+.post-image__preview {
+    .post-image__image {
+        max-width: 300px;
+    }
+
+    .post-image__info {
+        margin: 5px 0 5px 0;
+
+        .post-image__name {
+            font-size: .97em;
+            color: #717171;
+            margin-left: 5px;
+
+            &:after {
+                content: " \2022 ";
+            }
+        }
+
+        .post-image__size {
+            font-size: .97em;
+            color: #717171;
+        }
+    }
 }
 
 .post-image__details {

--- a/webapp/sass/layout/_post.scss
+++ b/webapp/sass/layout/_post.scss
@@ -982,7 +982,7 @@
         }
 
         img {
-            max-height: 400px;
+            max-height: 300px;
         }
 
         ul,

--- a/webapp/sass/responsive/_mobile.scss
+++ b/webapp/sass/responsive/_mobile.scss
@@ -1403,6 +1403,12 @@
     .integration__icon {
         display: none;
     }
+
+    .post-image__preview {
+        .post-image__image {
+            max-width: 100%;
+        }
+    }
 }
 
 @media screen and (max-height: 640px) {


### PR DESCRIPTION
Modify the file_attachment component to reflect new designs for image previews:
![screen shot 2016-12-07 at 1 52 16 pm](https://cloud.githubusercontent.com/assets/910657/20988210/9c15b1aa-bc84-11e6-848a-527f3f27a8f5.png)
![screen shot 2016-12-07 at 1 52 24 pm](https://cloud.githubusercontent.com/assets/910657/20988209/9c149360-bc84-11e6-9bf1-f4b03984ff7c.png)
![screen shot 2016-12-07 at 1 52 29 pm](https://cloud.githubusercontent.com/assets/910657/20988211/9c16cea0-bc84-11e6-9c6d-481a94050f4c.png)
![screen shot 2016-12-07 at 1 54 08 pm](https://cloud.githubusercontent.com/assets/910657/20988218/a3d43e3e-bc84-11e6-9fdc-746b6e58c465.png)
<img width="378" alt="screen shot 2016-12-07 at 1 55 31 pm" src="https://cloud.githubusercontent.com/assets/910657/20988256/d857ff06-bc84-11e6-98d1-7076c3aaa643.png">

- tested on mobile and desktop resolutions
- ran precommit style checks