### PR TITLE
UCHAT-285 DM modal has messed up layout on mobile

### DIFF
--- a/webapp/components/channel_invite_modal.jsx
+++ b/webapp/components/channel_invite_modal.jsx
@@ -152,7 +152,7 @@ export default class ChannelInviteModal extends React.Component {
 
         return (
             <Modal
-                dialogClassName='more-modal'
+                dialogClassName='more-modal list-members'
                 show={this.state.show}
                 onHide={this.onHide}
                 onExited={this.props.onHide}

--- a/webapp/components/more_channels_new.jsx
+++ b/webapp/components/more_channels_new.jsx
@@ -124,13 +124,17 @@ export default class MoreChannelsNew extends React.Component {
         const isAdmin = TeamStore.isTeamAdminForCurrentTeam() || UserStore.isSystemAdminForCurrentUser();
         const isSystemAdmin = UserStore.isSystemAdminForCurrentUser();
 
+        let noNewChannelBtnClass = '';
+
         if (global.window.mm_license.IsLicensed === 'true') {
             if (config.RestrictPublicChannelManagement === Constants.PERMISSIONS_SYSTEM_ADMIN && !isSystemAdmin) {
                 createNewChannelButton = null;
                 createChannelHelpText = null;
+                noNewChannelBtnClass = 'no-new-channel-btn';
             } else if (config.RestrictPublicChannelManagement === Constants.PERMISSIONS_TEAM_ADMIN && !isAdmin) {
                 createNewChannelButton = null;
                 createChannelHelpText = null;
+                noNewChannelBtnClass = 'no-new-channel-btn';
             }
         }
 
@@ -166,7 +170,7 @@ export default class MoreChannelsNew extends React.Component {
 
         return (
             <Modal
-                dialogClassName='more-modal more-channels'
+                dialogClassName={`more-modal more-channels ${noNewChannelBtnClass}`}
                 show={this.state.show}
                 onHide={this.handleHide}
                 onExited={this.props.onModalDismissed}

--- a/webapp/components/more_channels_new.jsx
+++ b/webapp/components/more_channels_new.jsx
@@ -166,7 +166,7 @@ export default class MoreChannelsNew extends React.Component {
 
         return (
             <Modal
-                dialogClassName='more-modal more-channels more-direct-channels'
+                dialogClassName='more-modal more-channels'
                 show={this.state.show}
                 onHide={this.handleHide}
                 onExited={this.props.onModalDismissed}

--- a/webapp/components/more_direct_channels.jsx
+++ b/webapp/components/more_direct_channels.jsx
@@ -186,7 +186,9 @@ export default class MoreDirectChannels extends React.Component {
 
     render() {
         let teamToggle;
+        let noFilterClass = 'no-team-filter';
         if (config.RestrictDirectMessage === 'any' && !config.DefaultTeamName) {
+            noFilterClass = '';
             teamToggle = (
                 <div className='member-select__container'>
                     <select
@@ -223,7 +225,7 @@ export default class MoreDirectChannels extends React.Component {
 
         return (
             <Modal
-                dialogClassName='more-modal more-direct-channels'
+                dialogClassName={`more-modal more-direct-channels ${noFilterClass}`}
                 show={this.state.show}
                 onHide={this.handleHide}
                 onExited={this.handleExit}

--- a/webapp/components/team_members_modal.jsx
+++ b/webapp/components/team_members_modal.jsx
@@ -47,7 +47,7 @@ export default class TeamMembersModal extends React.Component {
 
         return (
             <Modal
-                dialogClassName='more-modal'
+                dialogClassName='more-modal list-members'
                 show={this.state.show}
                 onHide={this.onHide}
                 onExited={this.props.onHide}

--- a/webapp/sass/responsive/_mobile.scss
+++ b/webapp/sass/responsive/_mobile.scss
@@ -1326,6 +1326,11 @@
                     max-height: calc(100vh - 265px);
                 }
             }
+            &.no-team-filter, &.no-new-channel-btn {
+                .more-modal__list {
+                    max-height: calc(100vh - 260px);
+                }
+            }
         }
 
         .modal {

--- a/webapp/sass/responsive/_mobile.scss
+++ b/webapp/sass/responsive/_mobile.scss
@@ -1314,17 +1314,16 @@
             }
 
             .more-modal__list {
-                max-height: calc(100vh - 260px);
+                max-height: calc(100vh - 306px);
             }
-
             &.more-direct-channels {
                 .more-modal__list {
-                    max-height: calc(100vh - 245px);
+                    max-height: calc(100vh - 316px);
                 }
             }
-            &.more-channels {
+            &.list-members {
                 .more-modal__list {
-                    max-height: calc(100vh - 306px);
+                    max-height: calc(100vh - 265px);
                 }
             }
         }


### PR DESCRIPTION
Ticket: https://jira.uberinternal.com/browse/UCHAT-285

These changes touch the height so that the scroll works properly. All members and channels modals should be tested:
- From the current channel menu: Add Members, View Members, Manage Members
- View Members (From the 3 dots drop down menu)
- More... (Channels)
- More... (Direct Message)

Added specific styles for special cases like in 'config/config.json' setting any of these values:
        "RestrictPublicChannelManagement": "all",
        "RestrictPrivateChannelManagement": "all",
        "DefaultTeamName": ""