### PR TITLE
UCHAT-282 Enclose OR so that the query executes with the proper parameters

### DIFF
--- a/store/sql_channel_store.go
+++ b/store/sql_channel_store.go
@@ -467,7 +467,7 @@ func (s SqlChannelStore) GetPaginatedChannels(teamId string, userId string, offs
 		if len(strings.TrimSpace(term)) == 0 {
 			searchQuery = strings.Replace(searchQuery, "SEARCH_CLAUSE", "", 1)
 		} else {
-			searchClause := fmt.Sprintf("AND Name like :Term OR DisplayName like :Term")
+			searchClause := fmt.Sprintf("AND (Name like :Term OR DisplayName like :Term)")
 			searchQuery = strings.Replace(searchQuery, "SEARCH_CLAUSE", searchClause, 1)
 		}
 


### PR DESCRIPTION
These changes fix:
UCHAT-282 - Channels pagination api doesn't filter by team
UCHAT-288 - Channel search is not respecting private rooms in modal
UCHAT-289 - In Channels modal, hide already joined channels

Tickets:
https://jira.uberinternal.com/browse/UCHAT-282
https://jira.uberinternal.com/browse/UCHAT-288
https://jira.uberinternal.com/browse/UCHAT-289