### PR TITLE
UCHAT-232 add error message to root.html that is displayed during network error

### DIFF
--- a/webapp/root.html
+++ b/webapp/root.html
@@ -36,10 +36,40 @@
 
     <!-- CSS Should always go first -->
     <link rel='stylesheet' class='code_theme'>
+    <style>
+        .error-screen {
+            font-family: 'Open Sans', sans-serif;
+            text-align: center;
+            padding-top: 50px;
+            color: #90d0bd;
+            display: none;
+        }
 
+        .error-screen-visible {
+            display: block;
+        }
+
+        .error-message {
+            padding-bottom: 50px;
+        }
+
+        .retry-button,
+        .retry-button:hover,
+        .retry-button:active,
+        .retry-button:visited {
+            border: 2px solid #90d0bd;
+            text-decoration: none;
+            color: #90d0bd;
+            padding: 10px;
+        }
+    </style>
 </head>
 <body>
     <div id='root'>
+        <div class='error-screen'>
+            <h1 class='error-message'>Cannot connect to uChat.</h1>
+            <a class='retry-button' onClick='window.location.reload();'>Try Again</a>
+        </div>
         <div
             class='loading-screen'
             style='position: relative'
@@ -52,6 +82,9 @@
         </div>
     </div>
     <script>
+        if (typeof window.setup_root === 'undefined' && !window.setup_root) {
+            document.querySelector('.error-screen').classList.add('error-screen-visible');
+        }
         window.setup_root();
     </script>
     <noscript>

--- a/webapp/root.html
+++ b/webapp/root.html
@@ -82,7 +82,7 @@
         </div>
     </div>
     <script>
-        if (typeof window.setup_root === 'undefined' && !window.setup_root) {
+        if (typeof window.setup_root !== 'function') {
             document.querySelector('.error-screen').classList.add('error-screen-visible');
         }
         window.setup_root();


### PR DESCRIPTION
Currently if network error (disconnect) occurs prior to all the javascript finishes loading, the user is presented with a blank page. This is because the `window.setup_root` function has not been set. This PR adds the following message to the screen when `window.setup_root` is `undefined`.
<img width="425" alt="screen shot 2016-12-08 at 3 36 08 pm" src="https://cloud.githubusercontent.com/assets/910657/21032108/11d55206-bd5c-11e6-97bd-5109c80a89d4.png">

I've tested this on 
- [x] iOS device
- [x] Android device
- [x] mac desktop

See [this video demo](https://drive.google.com/a/uber.com/file/d/0B33KDfvd_OtVNHJ3enBpMUNEMzg/view?usp=sharing) for iOS. 
❗️ Note: the loading takes a while because I was connecting through ngrok to my laptop from my iPhone .

Two related text changes:
https://github.com/csduarte/uchat-android/pull/14
https://github.com/csduarte/uchat-ios/pull/19


