### PR TITLE
UCHAT-306 Team selection link is displayed in RHS on mobile

### DIFF
--- a/webapp/components/sidebar_right_menu.jsx
+++ b/webapp/components/sidebar_right_menu.jsx
@@ -388,15 +388,17 @@ export default class SidebarRightMenu extends React.Component {
                         {teamSettingsLink}
                         {manageLink}
                         {consoleLink}
-                        <li>
-                            <Link to='/select_team'>
-                                <i className='icon fa fa-exchange'/>
-                                <FormattedMessage
-                                    id='sidebar_right_menu.switch_team'
-                                    defaultMessage='Team Selection'
-                                />
-                            </Link>
-                        </li>
+                        {global.window.mm_config.DefaultTeamName ? '' : (
+                            <li>
+                                <Link to='/select_team'>
+                                    <i className='icon fa fa-exchange'/>
+                                    <FormattedMessage
+                                        id='sidebar_right_menu.switch_team'
+                                        defaultMessage='Team Selection'
+                                    />
+                                </Link>
+                            </li>
+                        )}
                         <li className='divider'/>
                         {helpLink}
                         {reportLink}


### PR DESCRIPTION
Ticket: https://jira.uberinternal.com/browse/UCHAT-306
NOTE: It related to this previous PR: https://github.com/csduarte/platform/pull/3/files

Result when `DefaultTeamName` is set to an existing team:
![uchat-306_disableteamselectionlink](https://cloud.githubusercontent.com/assets/23249245/21077663/bfec126a-bf20-11e6-8b8e-fc5bec116137.png)

