### PR TITLE
UCHAT-150 add dropdown in sidebar header for changing status

### DIFF
--- a/api/status.go
+++ b/api/status.go
@@ -32,6 +32,7 @@ func InitStatus() {
 	l4g.Debug(utils.T("api.status.init.debug"))
 
 	BaseRoutes.Users.Handle("/status", ApiUserRequired(getStatusesHttp)).Methods("GET")
+	BaseRoutes.Users.Handle("/status", ApiUserRequired(setStatusByHttp)).Methods("POST")
 	BaseRoutes.Users.Handle("/status/ids", ApiUserRequired(getStatusesByIdsHttp)).Methods("POST")
 	BaseRoutes.Users.Handle("/status/set_active_channel", ApiUserRequired(setActiveChannel)).Methods("POST")
 	BaseRoutes.WebSocket.Handle("get_statuses", ApiWebSocketHandler(getStatusesWebSocket))
@@ -71,6 +72,23 @@ func GetAllStatuses() (map[string]interface{}, *model.AppError) {
 
 		return statusMap, nil
 	}
+}
+
+func setStatusByHttp(c *Context, w http.ResponseWriter, r *http.Request) {
+	status := model.StringFromJson(r.Body)
+
+	if status == model.STATUS_ONLINE {
+		SetStatusOnline(c.Session.UserId, c.Session.Id, true)
+	} else if status == model.STATUS_AWAY {
+		SetStatusAwayIfNeeded(c.Session.UserId, true)
+	} else if status == model.STATUS_OFFLINE {
+		SetStatusOffline(c.Session.UserId, true)
+	} else {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	ReturnStatusOK(w)
 }
 
 func getStatusesByIdsHttp(c *Context, w http.ResponseWriter, r *http.Request) {

--- a/api/status_test.go
+++ b/api/status_test.go
@@ -202,6 +202,38 @@ func TestStatuses(t *testing.T) {
 	WebSocketClient.Close()
 }
 
+func TestSetStatus(t *testing.T) {
+	th := Setup().InitBasic()
+	Client := th.BasicClient
+
+	team := model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
+	rteam, _ := Client.CreateTeam(&team)
+
+	user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1"}
+	ruser := Client.Must(Client.CreateUser(&user, "")).Data.(*model.User)
+	LinkUserToTeam(ruser, rteam.Data.(*model.Team))
+	store.Must(Srv.Store.User().VerifyEmail(ruser.Id))
+
+	Client.Login(user.Email, user.Password)
+	Client.SetTeamId(team.Id)
+
+	if _, err := Client.SetStatus("hello world"); err == nil {
+		t.Fatal("should fail when status string does not match existing")
+	}
+
+	if _, err := Client.SetStatus("online"); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Client.SetStatus("away"); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Client.SetStatus("offline"); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestGetStatusesByIds(t *testing.T) {
 	th := Setup().InitBasic()
 	Client := th.BasicClient

--- a/model/client.go
+++ b/model/client.go
@@ -1625,6 +1625,18 @@ func (c *Client) GetStatuses() (*Result, *AppError) {
 	}
 }
 
+// SetStatus sets the current user's status, and if the given string
+// does not match any of the existing statuses, then 400 is returned
+func (c *Client) SetStatus(status string) (*Result, *AppError) {
+	if r, err := c.DoApiPost("/users/status", StringToJson(status)); err != nil {
+		return nil, err
+	} else {
+		defer closeBody(r)
+		return &Result{r.Header.Get(HEADER_REQUEST_ID),
+			r.Header.Get(HEADER_ETAG_SERVER), MapFromJson(r.Body)}, nil
+	}
+}
+
 // GetStatusesByIds returns a map of string statuses using user id as the key,
 // based on the provided user ids
 func (c *Client) GetStatusesByIds(userIds []string) (*Result, *AppError) {

--- a/webapp/client/client.jsx
+++ b/webapp/client/client.jsx
@@ -1124,6 +1124,16 @@ export default class Client {
             end(this.handleResponse.bind(this, 'getStatuses', success, error));
     }
 
+    setStatus(status, success, error) {
+        request.
+            post(`${this.getUsersRoute()}/status`).
+            set(this.defaultHeaders).
+            type('application/json').
+            accept('application/json').
+            send(JSON.stringify(status)).
+            end(this.handleResponse.bind(this, 'setStatus', success, error));
+    }
+
     getStatusesByIds(userIds, success, error) {
         request.
             post(`${this.getUsersRoute()}/status/ids`).

--- a/webapp/components/admin_console/admin_sidebar_header.jsx
+++ b/webapp/components/admin_console/admin_sidebar_header.jsx
@@ -48,15 +48,14 @@ export default class SidebarHeader extends React.Component {
         }
 
         return (
-            <div className='team__header theme'>
-                <a
-                    href='#'
-                    onClick={this.toggleDropdown}
-                >
+            <div
+                className='team__header theme'
+                onClick={this.toggleDropdown}
+            >
+                <a href='#'>
                     {profilePicture}
                     <div className='header__info'>
-                        <div className='user__name'>{'@' + me.username}</div>
-                        <div className='full__name'>
+                        <div className='system-console__label'>
                             <FormattedMessage
                                 id='admin.sidebarHeader.systemConsole'
                                 defaultMessage='System Console'

--- a/webapp/components/sidebar.jsx
+++ b/webapp/components/sidebar.jsx
@@ -108,6 +108,7 @@ export default class Sidebar extends React.Component {
             showTutorialTip: tutorialStep === TutorialSteps.CHANNEL_POPOVER,
             currentTeam: TeamStore.getCurrent(),
             currentUser: UserStore.getCurrentUser(),
+            currentUserStatus: UserStore.getStatus(UserStore.getCurrentUser().id),
             townSquare: ChannelStore.getByName(Constants.DEFAULT_CHANNEL),
             offTopic: ChannelStore.getByName(Constants.OFFTOPIC_CHANNEL)
         };
@@ -773,6 +774,7 @@ export default class Sidebar extends React.Component {
                     teamName={this.state.currentTeam.name}
                     teamType={this.state.currentTeam.type}
                     currentUser={this.state.currentUser}
+                    currentUserStatus={this.state.currentUserStatus}
                 />
 
                 <UnreadChannelIndicator

--- a/webapp/components/sidebar_header.jsx
+++ b/webapp/components/sidebar_header.jsx
@@ -3,21 +3,26 @@
 
 import React from 'react';
 
-import Client from 'client/web_client.jsx';
 import PreferenceStore from 'stores/preference_store.jsx';
 import * as Utils from 'utils/utils.jsx';
 
 import SidebarHeaderDropdown from './sidebar_header_dropdown.jsx';
+import SidebarHeaderStatusDropdown from './sidebar_header_status_dropdown.jsx';
 import {Tooltip, OverlayTrigger} from 'react-bootstrap';
 
 import {Preferences, TutorialSteps} from 'utils/constants.jsx';
 import {createMenuTip} from 'components/tutorial/tutorial_tip.jsx';
+
+import statusAway from 'images/icons/IC_DM_Away.svg';
+import statusOnline from 'images/icons/IC_DM_Online.svg';
+import statusOffline from 'images/icons/IC_DM_Offline.svg';
 
 export default class SidebarHeader extends React.Component {
     constructor(props) {
         super(props);
 
         this.toggleDropdown = this.toggleDropdown.bind(this);
+        this.toggleStatusDropdown = this.toggleStatusDropdown.bind(this);
         this.onPreferenceChange = this.onPreferenceChange.bind(this);
 
         this.state = this.getStateFromStores();
@@ -47,22 +52,18 @@ export default class SidebarHeader extends React.Component {
         this.refs.dropdown.toggleDropdown();
     }
 
+    toggleStatusDropdown(e) {
+        e.preventDefault();
+
+        this.refs.statusDropdown.toggleDropdown();
+    }
+
     render() {
         var me = this.props.currentUser;
         const fullName = Utils.getFullName(me);
-        var profilePicture = null;
 
         if (!me) {
             return null;
-        }
-
-        if (me.last_picture_update) {
-            profilePicture = (
-                <img
-                    className='user__picture'
-                    src={Client.getUsersRoute() + '/' + me.id + '/image?time=' + me.update_at}
-                />
-            );
         }
 
         let tutorialTip = null;
@@ -70,16 +71,35 @@ export default class SidebarHeader extends React.Component {
             tutorialTip = createMenuTip(this.toggleDropdown);
         }
 
+        let statusIconUrl;
+        switch (this.props.currentUserStatus) {
+        case 'away':
+            statusIconUrl = statusAway;
+            break;
+        case 'online':
+            statusIconUrl = statusOnline;
+            break;
+        case 'offline':
+            statusIconUrl = statusOffline;
+            break;
+        }
+
         return (
             <div className='team__header theme'>
                 {tutorialTip}
                 <a
                     href='#'
-                    onClick={this.toggleDropdown}
+                    onClick={this.toggleStatusDropdown}
                 >
-                    {profilePicture}
                     <div className='header__info'>
-                        <div className='user__name'>{'@' + me.username}</div>
+                        <div className='header__status-border'>
+                            <div
+                                className='header__status'
+                                style={{
+                                    backgroundImage: `url(${statusIconUrl})`
+                                }}
+                            />
+                        </div>
                         <OverlayTrigger
                             className='hidden-xs'
                             trigger={['hover', 'focus']}
@@ -106,6 +126,9 @@ export default class SidebarHeader extends React.Component {
                     teamName={this.props.teamName}
                     currentUser={this.props.currentUser}
                 />
+                <SidebarHeaderStatusDropdown
+                    ref='statusDropdown'
+                />
             </div>
         );
     }
@@ -119,5 +142,6 @@ SidebarHeader.propTypes = {
     teamDisplayName: React.PropTypes.string,
     teamName: React.PropTypes.string,
     teamType: React.PropTypes.string,
-    currentUser: React.PropTypes.object
+    currentUser: React.PropTypes.object,
+    currentUserStatus: React.PropTypes.string
 };

--- a/webapp/components/sidebar_header_status_dropdown.jsx
+++ b/webapp/components/sidebar_header_status_dropdown.jsx
@@ -1,0 +1,128 @@
+// Copyright (c) 2015 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React from 'react';
+
+import {Dropdown} from 'react-bootstrap';
+import {FormattedMessage} from 'react-intl';
+
+import Client from 'client/web_client.jsx';
+import Constants from 'utils/constants.jsx';
+import * as AsyncClient from 'utils/async_client.jsx';
+
+import statusAway from 'images/icons/IC_DM_Away.svg';
+import statusOnline from 'images/icons/IC_DM_Online.svg';
+import statusOffline from 'images/icons/IC_DM_Offline.svg';
+
+export default class SidebarHeaderStatusDropdown extends React.Component {
+    static propTypes = {
+        status: React.PropTypes.string
+    };
+
+    constructor(props) {
+        super(props);
+
+        this.toggleDropdown = this.toggleDropdown.bind(this);
+        this.setUserAway = this.setUserAway.bind(this);
+        this.setUserOnline = this.setUserOnline.bind(this);
+        this.setUserOffline = this.setUserOffline.bind(this);
+
+        this.state = {
+            showDropdown: false
+        };
+    }
+
+    toggleDropdown(e) {
+        if (e) {
+            e.preventDefault();
+        }
+
+        this.setState({showDropdown: !this.state.showDropdown});
+    }
+
+    setUserAway() {
+        this.toggleDropdown();
+        Client.setStatus(Constants.UserStatuses.AWAY,
+            () => {
+                // DO nothing.
+            },
+            (err) => {
+                AsyncClient.dispatchError(err, 'setStatus');
+            }
+        );
+    }
+
+    setUserOnline() {
+        this.toggleDropdown();
+        Client.setStatus(Constants.UserStatuses.ONLINE,
+            () => {
+                // DO nothing.
+            },
+            (err) => {
+                AsyncClient.dispatchError(err, 'setStatus');
+            }
+        );
+    }
+
+    setUserOffline() {
+        this.toggleDropdown();
+        Client.setStatus(Constants.UserStatuses.OFFLINE,
+            () => {
+                // DO nothing.
+            },
+            (err) => {
+                AsyncClient.dispatchError(err, 'setStatus');
+            }
+        );
+    }
+
+    render() {
+        return (
+            <Dropdown
+                open={this.state.showDropdown}
+                onClose={this.toggleDropdown}
+                className='sidebar-header-status-dropdown'
+                pullRight={true}
+            >
+                <Dropdown.Menu>
+                    <li>
+                        <a
+                            href='#'
+                            onClick={this.setUserOnline}
+                        >
+                            <img src={statusOnline}/>
+                            <FormattedMessage
+                                id='yes'
+                                defaultMessage='Available'
+                            />
+                        </a>
+                    </li>
+                    <li>
+                        <a
+                            href='#'
+                            onClick={this.setUserAway}
+                        >
+                            <img src={statusAway}/>
+                            <FormattedMessage
+                                id='yes'
+                                defaultMessage='Away'
+                            />
+                        </a>
+                    </li>
+                    <li>
+                        <a
+                            href='#'
+                            onClick={this.setUserOffline}
+                        >
+                            <img src={statusOffline}/>
+                            <FormattedMessage
+                                id='yes'
+                                defaultMessage='Offline'
+                            />
+                        </a>
+                    </li>
+                </Dropdown.Menu>
+            </Dropdown>
+        );
+    }
+}

--- a/webapp/images/icons/IC_DM_Away.svg
+++ b/webapp/images/icons/IC_DM_Away.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="12px" height="12px" viewBox="0 0 12 12" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 41.2 (35397) - http://www.bohemiancoding.com/sketch -->
+    <title>profile</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Notification-Sidebar" transform="translate(-361.000000, -691.000000)" fill="#ECAB20">
+            <g id="Left_Sidebar" transform="translate(345.000000, 138.000000)">
+                <g id="List" transform="translate(0.000000, 76.000000)">
+                    <g id="Profile_Default" transform="translate(0.000000, 468.000000)">
+                        <g id="profile" transform="translate(16.000000, 9.000000)">
+                            <path d="M8.95917045,2.98639015 C8.95917045,4.63587297 7.62226312,5.9727803 5.9727803,5.9727803 C4.32329747,5.9727803 2.98639015,4.63587297 2.98639015,2.98639015 C2.98639015,1.33690732 4.32329747,0 5.9727803,0 C7.62226312,0 8.95917045,1.33690732 8.95917045,2.98639015 L8.95917045,2.98639015 Z M6,7.5 C2.179,7.5 0,10.007 0,10.007 L0,11 C0,11.552 0.448,12 1,12 L11,12 C11.552,12 12,11.552 12,11 L12,10.007 C12,10.007 9.821,7.5 6,7.5 L6,7.5 Z"></path>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/webapp/images/icons/IC_DM_Offline.svg
+++ b/webapp/images/icons/IC_DM_Offline.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="12px" height="12px" viewBox="0 0 12 12" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 41.2 (35397) - http://www.bohemiancoding.com/sketch -->
+    <title>profile</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Notification-Sidebar" transform="translate(-361.000000, -631.000000)" fill="#A6A5A5">
+            <g id="Left_Sidebar" transform="translate(345.000000, 138.000000)">
+                <g id="List" transform="translate(0.000000, 76.000000)">
+                    <g id="Profile_Default" transform="translate(0.000000, 408.000000)">
+                        <g id="profile" transform="translate(16.000000, 9.000000)">
+                            <path d="M8.95917045,2.98639015 C8.95917045,4.63587297 7.62226312,5.9727803 5.9727803,5.9727803 C4.32329747,5.9727803 2.98639015,4.63587297 2.98639015,2.98639015 C2.98639015,1.33690732 4.32329747,0 5.9727803,0 C7.62226312,0 8.95917045,1.33690732 8.95917045,2.98639015 L8.95917045,2.98639015 Z M6,7.5 C2.179,7.5 0,10.007 0,10.007 L0,11 C0,11.552 0.448,12 1,12 L11,12 C11.552,12 12,11.552 12,11 L12,10.007 C12,10.007 9.821,7.5 6,7.5 L6,7.5 Z"></path>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/webapp/images/icons/IC_DM_Online.svg
+++ b/webapp/images/icons/IC_DM_Online.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="12px" height="12px" viewBox="0 0 12 12" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 41.2 (35397) - http://www.bohemiancoding.com/sketch -->
+    <title>profile</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Notification-Sidebar" transform="translate(-361.000000, -661.000000)" fill="#629A41">
+            <g id="Left_Sidebar" transform="translate(345.000000, 138.000000)">
+                <g id="List" transform="translate(0.000000, 76.000000)">
+                    <g id="Profile_Default" transform="translate(0.000000, 438.000000)">
+                        <g id="profile" transform="translate(16.000000, 9.000000)">
+                            <path d="M8.95917045,2.98639015 C8.95917045,4.63587297 7.62226312,5.9727803 5.9727803,5.9727803 C4.32329747,5.9727803 2.98639015,4.63587297 2.98639015,2.98639015 C2.98639015,1.33690732 4.32329747,0 5.9727803,0 C7.62226312,0 8.95917045,1.33690732 8.95917045,2.98639015 L8.95917045,2.98639015 Z M6,7.5 C2.179,7.5 0,10.007 0,10.007 L0,11 C0,11.552 0.448,12 1,12 L11,12 C11.552,12 12,11.552 12,11 L12,10.007 C12,10.007 9.821,7.5 6,7.5 L6,7.5 Z"></path>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/webapp/sass/layout/_headers.scss
+++ b/webapp/sass/layout/_headers.scss
@@ -230,8 +230,12 @@
 
     .team__header {
         @include legacy-pie-clearfix;
-        padding: 9px 10px;
+        @include display-flex;
+        @include align-items(center);
+        @include justify-content(space-between);
         position: relative;
+        height: 45px;
+        cursor: pointer;
 
         &:before {
             @include single-transition(all, .05s, linear);
@@ -264,19 +268,44 @@
                     @include opacity(1);
                 }
             }
+
+            .header__info {
+                .header__status-border {
+                    background: rgba($white, 0.7);
+                }
+            }
         }
 
         a {
             text-decoration: none;
+            width: 100%;
+        }
+
+        .sidebar-header-status-dropdown {
+            ul {
+                top: 22px;
+                right: 1px;
+                margin: 0;
+                padding: 0;
+                width: 220px;
+                max-width: 220px;
+
+                li {
+                    a {
+                        padding: 10px;
+                    }
+
+                    img {
+                        padding: 0 12px 0 6px;
+                    }
+                }
+            }
         }
 
         .sidebar-header-dropdown,
         .admin-navbar-dropdown {
             font-size: .85em;
-            position: absolute;
-            margin-right: -15px;
-            right: 22px;
-            top: 10px;
+            right: 1px;
             z-index: 5;
 
             .sidebar-header-dropdown__toggle,
@@ -287,14 +316,17 @@
                 color: $white;
                 float: right;
                 font-size: 1em;
-                line-height: 1.8;
-                padding: 10px;
+                padding: 13px 10px;
+            }
+
+            .admin-navbar-dropdown__toggle {
+                margin-left: 15px;
             }
 
             .dropdown-menu {
-                width: 199px;
-                margin-top: 4px;
-                margin-right: 3px;
+                width: 220px;
+                max-width: 220px;
+                margin-top: 0;
 
                 a {
                     overflow: hidden;
@@ -306,6 +338,12 @@
             .sidebar-header-dropdown__icon,
             .admin-navbar-dropdown__icon {
                 fill: $white;
+            }
+        }
+
+        .admin-navbar-dropdown {
+            .dropdown-menu {
+                right: 15px;
             }
         }
 
@@ -321,21 +359,36 @@
         .header__info {
             @include clearfix;
             @include display-flex;
-            @include flex-direction(column);
-            @include justify-content(center);
+            @include align-items(center);
             color: $white;
-            padding-left: 2px;
             position: relative;
             min-height: 38px;
             z-index: 1;
+
+            .header__status-border {
+                @include border-radius(100%);
+                margin: 0 6px 0 10px;
+
+                .header__status {
+                    @include border-radius(100%);
+                    width: 22px;
+                    height: 22px;
+                    margin: 2px;
+                    background-color: $white;
+                    background-repeat: no-repeat;
+                    background-position: center;
+                }
+            }
+
         }
 
         .full__name,
-        .user__name {
+        .user__name,
+        .system-console__label {
             display: block;
             font-size: 16px;
             font-weight: 600;
-            max-width: 85%;
+            width: 155px;
             overflow: hidden;
             text-decoration: none;
             text-overflow: ellipsis;
@@ -345,7 +398,6 @@
         .full__name {
             float: left;
             line-height: 22px;
-            margin-top: -2px;
         }
 
         .user__name {
@@ -354,6 +406,10 @@
             font-size: 14px;
             font-weight: 400;
             line-height: 18px;
+        }
+
+        .system-console__label {
+            padding-left: 10px;
         }
     }
 

--- a/webapp/sass/responsive/_mobile.scss
+++ b/webapp/sass/responsive/_mobile.scss
@@ -927,10 +927,6 @@
             height: 100%;
         }
 
-        > div {
-            padding-bottom: 70px;
-        }
-
         .nav-pills__unread-indicator-bottom {
             bottom: 10px;
         }
@@ -940,15 +936,20 @@
         }
 
         .team__header {
-            @include clearfix;
-            pointer-events: none;
-
             .team__name {
                 margin: 10px 0;
             }
 
             .sidebar-header-dropdown {
                 display: none;
+            }
+
+            .sidebar-header-status-dropdown {
+                ul {
+                    right: 0;
+                    width: 290px;
+                    max-width: 290px;
+                }
             }
         }
 
@@ -1405,6 +1406,15 @@
     .sidebar--left {
         @include translate3d(-260px, 0, 0);
         width: 260px;
+
+        .team__header {
+            .sidebar-header-status-dropdown {
+                ul {
+                    width: 260px;
+                    max-width: 260px;
+                }
+            }
+        }
     }
 
     .inner-wrap {

--- a/webapp/tests/client_user.test.jsx
+++ b/webapp/tests/client_user.test.jsx
@@ -587,6 +587,20 @@ describe('Client.User', function() {
         });
     });
 
+    it('setStatus', function(done) {
+        TestHelper.initBasic(() => {
+            TestHelper.basicClient().setStatus(
+                'online',
+                function() {
+                    done();
+                },
+                function(err) {
+                    done(new Error(err.message));
+                }
+            );
+        });
+    });
+
     it('getStatusesByIds', function(done) {
         TestHelper.initBasic(() => {
             var ids = [];

--- a/webapp/utils/utils.jsx
+++ b/webapp/utils/utils.jsx
@@ -628,6 +628,7 @@ export function applyTheme(theme) {
         changeCss('.app__body .post.post--comment.current--user .post__body', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.2), 1);
         changeCss('.app__body .channel-header__info .status .offline--icon', 'fill:' + theme.centerChannelColor, 1);
         changeCss('.app__body .navbar .status .offline--icon', 'fill:' + theme.centerChannelColor, 1);
+        changeCss('.sidebar--left .team__header .sidebar-header-status-dropdown ul li:not(:last-child)', 'border-bottom:1px solid ' + changeOpacity(theme.centerChannelColor, 0.2), 1);
     }
 
     if (theme.newMessageSeparator) {


### PR DESCRIPTION
![demo](https://cloud.githubusercontent.com/assets/910657/21122983/9936db1c-c08a-11e6-8294-06c8d4919f1e.gif)

### Change log:
- Add a status dropdown to allow user to manually set status
- Add an endpoint to set status 
    - `POST /users/status`
    - POST body is a JSON string denoting the status (e.g. "online", "offline", and "away")
- Add basic client and server unit test for set status endpoint (test passes locally)
- Modify sidebar header to conform with latest designs
- Tested CSS styles on system console
<img width="439" alt="screen shot 2016-12-12 at 4 45 39 pm" src="https://cloud.githubusercontent.com/assets/910657/21122973/86173716-c08a-11e6-98cd-ca2568fa5b80.png">

- Tested CSS styles on mobile resolutions
<img width="487" alt="screen shot 2016-12-12 at 4 52 12 pm" src="https://cloud.githubusercontent.com/assets/910657/21123087/5ca7ac02-c08b-11e6-8f8d-d26428f6e8ca.png">

- Tested on dark theme
<img width="448" alt="screen shot 2016-12-12 at 4 25 36 pm" src="https://cloud.githubusercontent.com/assets/910657/21122967/80288706-c08a-11e6-88b2-3a5fe694c851.png">

- Tested users with varying lengths of names (for dev only, if the user does not have firstname and lastname, then the following is displayed:)
<img width="332" alt="screen shot 2016-12-12 at 4 10 53 pm" src="https://cloud.githubusercontent.com/assets/910657/21123008/c789f468-c08a-11e6-8784-6853e3a6cdf7.png">

