### PR TITLE
UCHAT-211 display fullname in channel switcher suggestions

### DIFF
--- a/webapp/components/suggestion/switch_channel_provider.jsx
+++ b/webapp/components/suggestion/switch_channel_provider.jsx
@@ -86,7 +86,7 @@ export default class SwitchChannelProvider {
                             }
 
                             const newChannel = {
-                                display_name: user.username,
+                                display_name: Utils.getFullName(user) + ' - ' + user.username,
                                 name: user.username + ' ' + Utils.localizeMessage('channel_switch_modal.dm', '(Direct Message)'),
                                 type: Constants.DM_CHANNEL
                             };


### PR DESCRIPTION
Display full names in our current channel switcher design:
<img width="604" alt="screen shot 2016-12-20 at 11 33 43 pm" src="https://cloud.githubusercontent.com/assets/910657/21380848/c830eefc-c70c-11e6-8210-1a950de5cacb.png">

Because the designs are not final, this is just a quick simple fix to get the full name to show as part of the suggestions.