### PR TITLE
UCHAT-448 add an API for admins to modify user preferences

### DIFF
--- a/api/preference_test.go
+++ b/api/preference_test.go
@@ -86,6 +86,28 @@ func TestSetPreferences(t *testing.T) {
 	}
 }
 
+func TestSetPreferencesAdmin(t *testing.T) {
+	th := Setup().InitBasic().InitSystemAdmin()
+	Client := th.SystemAdminClient
+	user1 := th.BasicUser
+
+	// save 10 preferences
+	var preferences model.Preferences
+	for i := 0; i < 10; i++ {
+		preference := model.Preference{
+			UserId:   user1.Id,
+			Category: model.PREFERENCE_CATEGORY_DIRECT_CHANNEL_SHOW,
+			Name:     model.NewId(),
+		}
+		preferences = append(preferences, preference)
+	}
+
+	th.LoginSystemAdmin()
+	if _, err := Client.SetPreferencesAdmin(&preferences); err != nil {
+		t.Fatal("should have been able to update another user's preferences")
+	}
+}
+
 func TestGetPreferenceCategory(t *testing.T) {
 	th := Setup().InitBasic()
 	Client := th.BasicClient

--- a/model/client.go
+++ b/model/client.go
@@ -1882,6 +1882,16 @@ func (c *Client) SetPreferences(preferences *Preferences) (*Result, *AppError) {
 	}
 }
 
+func (c *Client) SetPreferencesAdmin(preferences *Preferences) (*Result, *AppError) {
+	if r, err := c.DoApiPost("/preferences/admin/save", preferences.ToJson()); err != nil {
+		return nil, err
+	} else {
+		defer closeBody(r)
+		return &Result{r.Header.Get(HEADER_REQUEST_ID),
+			r.Header.Get(HEADER_ETAG_SERVER), preferences}, nil
+	}
+}
+
 func (c *Client) GetPreference(category string, name string) (*Result, *AppError) {
 	if r, err := c.DoApiGet("/preferences/"+category+"/"+name, "", ""); err != nil {
 		return nil, err


### PR DESCRIPTION
- Added `POST /preferences/admin/save` to allow system admin to set preference for a user with the given user_id
- Added unit test
- Tested on Postman:

`POST http://localhost:8065/api/v3/preferences/save`
response:
```
{
  "id": "api.preference.save_preferences.set.app_error",
  "message": "Unable to set preferences for other user",
  "detailed_error": "session.user_id=3pkog3y58jbxtnc6r1hw71xtbh, preference.user_id=18g4i9bmnty7zqub4eps77fpwe",
  "request_id": "pspn45gchbf6bj1w3x87pm4gec",
  "status_code": 403
}
```

`POST http://localhost:8065/api/v3/preferences/admin/save`
response:
`true`