### PR TITLE
uChat hotfix for profile wipe

### DIFF
--- a/api/user.go
+++ b/api/user.go
@@ -1234,17 +1234,21 @@ func getProfileImage(c *Context, w http.ResponseWriter, r *http.Request) {
 			}
 		} else {
 			path := "users/" + id + "/profile.png"
+			readFailed := false
 
 			if data, err := ReadFile(path); err != nil {
+				readFailed = true
 
 				if img, err = createProfileImage(result.Data.(*model.User).Username, id); err != nil {
 					c.Err = err
 					return
 				}
 
-				if err := WriteFile(img, path); err != nil {
-					c.Err = err
-					return
+				if result.Data.(*model.User).LastPictureUpdate == 0 {
+					if err := WriteFile(img, path); err != nil {
+						c.Err = err
+						return
+					}
 				}
 
 			} else {
@@ -1252,7 +1256,7 @@ func getProfileImage(c *Context, w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		if c.Session.UserId == id {
+		if c.Session.UserId == id || readFailed {
 			w.Header().Set("Cache-Control", "max-age=300, public") // 5 mins
 		} else {
 			w.Header().Set("Cache-Control", "max-age=86400, public") // 24 hrs

--- a/api/user.go
+++ b/api/user.go
@@ -1219,6 +1219,7 @@ func createProfileImage(username string, userId string) ([]byte, *model.AppError
 func getProfileImage(c *Context, w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 	id := params["user_id"]
+	readFailed := false
 
 	if result := <-Srv.Store.User().Get(id); result.Err != nil {
 		c.Err = result.Err
@@ -1234,7 +1235,6 @@ func getProfileImage(c *Context, w http.ResponseWriter, r *http.Request) {
 			}
 		} else {
 			path := "users/" + id + "/profile.png"
-			readFailed := false
 
 			if data, err := ReadFile(path); err != nil {
 				readFailed = true


### PR DESCRIPTION
When the server cannot read from S3 it creates a temporary image and *somehow* saves it back to s3, this effectively overwrites the user's profile image.

This hotfix will prevent the writing of the default image if the profile picture has ever been modified. The default image will serve an image cached for 300 seconds.