### PR TITLE
UCHAT-465 - Return 400 bad request codes for webhooks when attachment or text is too long (#4879)

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -5184,6 +5184,14 @@
     "translation": "No text specified"
   },
   {
+    "id": "web.incoming_webhook.text.length.app_error",
+    "translation": "Maximum text length is {{.Max}} characters, received size is {{.Actual}}"
+  },
+  {
+    "id": "web.incoming_webhook.attachment.app_error",
+    "translation": "Maximum attachments length is {{.Max}} characters, received size is {{.Actual}}"
+  },
+  {
     "id": "web.incoming_webhook.user.app_error",
     "translation": "Couldn't find the user"
   },

--- a/model/post.go
+++ b/model/post.go
@@ -19,6 +19,11 @@ const (
 	POST_HEADER_CHANGE         = "system_header_change"
 	POST_CHANNEL_DELETED       = "system_channel_deleted"
 	POST_EPHEMERAL             = "system_ephemeral"
+	POST_FILEIDS_MAX_RUNES     = 150
+	POST_FILENAMES_MAX_RUNES   = 4000
+	POST_HASHTAGS_MAX_RUNES    = 1000
+	POST_MESSAGE_MAX_RUNES     = 4000
+	POST_PROPS_MAX_RUNES       = 8000
 )
 
 type Post struct {
@@ -102,11 +107,11 @@ func (o *Post) IsValid() *AppError {
 		return NewLocAppError("Post.IsValid", "model.post.is_valid.original_id.app_error", nil, "")
 	}
 
-	if utf8.RuneCountInString(o.Message) > 4000 {
+	if utf8.RuneCountInString(o.Message) > POST_MESSAGE_MAX_RUNES {
 		return NewLocAppError("Post.IsValid", "model.post.is_valid.msg.app_error", nil, "id="+o.Id)
 	}
 
-	if utf8.RuneCountInString(o.Hashtags) > 1000 {
+	if utf8.RuneCountInString(o.Hashtags) > POST_HASHTAGS_MAX_RUNES {
 		return NewLocAppError("Post.IsValid", "model.post.is_valid.hashtags.app_error", nil, "id="+o.Id)
 	}
 
@@ -115,15 +120,15 @@ func (o *Post) IsValid() *AppError {
 		return NewLocAppError("Post.IsValid", "model.post.is_valid.type.app_error", nil, "id="+o.Type)
 	}
 
-	if utf8.RuneCountInString(ArrayToJson(o.Filenames)) > 4000 {
+	if utf8.RuneCountInString(ArrayToJson(o.Filenames)) > POST_FILENAMES_MAX_RUNES {
 		return NewLocAppError("Post.IsValid", "model.post.is_valid.filenames.app_error", nil, "id="+o.Id)
 	}
 
-	if utf8.RuneCountInString(ArrayToJson(o.FileIds)) > 150 {
+	if utf8.RuneCountInString(ArrayToJson(o.FileIds)) > POST_FILEIDS_MAX_RUNES {
 		return NewLocAppError("Post.IsValid", "model.post.is_valid.file_ids.app_error", nil, "id="+o.Id)
 	}
 
-	if utf8.RuneCountInString(StringInterfaceToJson(o.Props)) > 8000 {
+	if utf8.RuneCountInString(StringInterfaceToJson(o.Props)) > POST_PROPS_MAX_RUNES {
 		return NewLocAppError("Post.IsValid", "model.post.is_valid.props.app_error", nil, "id="+o.Id)
 	}
 


### PR DESCRIPTION
Ticket: https://jira.uberinternal.com/browse/UCHAT-465
Reference from MM: https://github.com/mattermost/platform/pull/4879

Issue: A fairly serious performance issues caused by a heavy user bot/service. Partial solution: Webhook errors should not return 500s, but 400s so that the bot will know not to retry