### PR TITLE
UCHAT-472 Add setting to hide email/username signin and adjust styling

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -111,6 +111,8 @@
         "AmazonS3SSL": true
     },
     "EmailSettings": {
+        "EmailSignInHidden": true,
+        "UsernameSignInHidden": true,
         "EnableSignUpWithEmail": true,
         "EnableSignInWithEmail": true,
         "EnableSignInWithUsername": true,

--- a/model/config.go
+++ b/model/config.go
@@ -161,7 +161,9 @@ type FileSettings struct {
 type EmailSettings struct {
 	EnableSignUpWithEmail     bool
 	EnableSignInWithEmail     *bool
+	EmailSignInHidden         *bool
 	EnableSignInWithUsername  *bool
+	UsernameSignInHidden      *bool
 	SendEmailNotifications    bool
 	EmailNotificationContents *string
 	RequireEmailVerification  bool
@@ -549,6 +551,16 @@ func (o *Config) SetDefaults() {
 		}
 	}
 
+	if o.EmailSettings.EmailSignInHidden == nil {
+		o.EmailSettings.EmailSignInHidden = new(bool)
+
+		if o.EmailSettings.EnableSignUpWithEmail == true {
+			*o.EmailSettings.EmailSignInHidden = true
+		} else {
+			*o.EmailSettings.EmailSignInHidden = false
+		}
+	}
+
 	if o.EmailSettings.EmailNotificationContents == nil {
 		o.EmailSettings.EmailNotificationContents = new(string)
 		*o.EmailSettings.EmailNotificationContents = FULL_NOTIFICATION
@@ -557,6 +569,11 @@ func (o *Config) SetDefaults() {
 	if o.EmailSettings.EnableSignInWithUsername == nil {
 		o.EmailSettings.EnableSignInWithUsername = new(bool)
 		*o.EmailSettings.EnableSignInWithUsername = false
+	}
+
+	if o.EmailSettings.UsernameSignInHidden == nil {
+		o.EmailSettings.UsernameSignInHidden = new(bool)
+		*o.EmailSettings.UsernameSignInHidden = false
 	}
 
 	if o.EmailSettings.SendPushNotifications == nil {

--- a/utils/config.go
+++ b/utils/config.go
@@ -268,6 +268,8 @@ func getClientConfig(c *model.Config) map[string]string {
 	props["EnableSignUpWithEmail"] = strconv.FormatBool(c.EmailSettings.EnableSignUpWithEmail)
 	props["EnableSignInWithEmail"] = strconv.FormatBool(*c.EmailSettings.EnableSignInWithEmail)
 	props["EnableSignInWithUsername"] = strconv.FormatBool(*c.EmailSettings.EnableSignInWithUsername)
+	props["EmailSignInHidden"] = strconv.FormatBool(*c.EmailSettings.EmailSignInHidden)
+	props["UsernameSignInHidden"] = strconv.FormatBool(*c.EmailSettings.UsernameSignInHidden)
 	props["RequireEmailVerification"] = strconv.FormatBool(c.EmailSettings.RequireEmailVerification)
 	props["EnableEmailBatching"] = strconv.FormatBool(*c.EmailSettings.EnableEmailBatching)
 

--- a/utils/diagnostic.go
+++ b/utils/diagnostic.go
@@ -120,6 +120,8 @@ func trackConfig() {
 		"enable_sign_up_with_email":    Cfg.EmailSettings.EnableSignUpWithEmail,
 		"enable_sign_in_with_email":    *Cfg.EmailSettings.EnableSignInWithEmail,
 		"enable_sign_in_with_username": *Cfg.EmailSettings.EnableSignInWithUsername,
+		"email_sign_in_hidden":         *Cfg.EmailSettings.EmailSignInHidden,
+		"username_sign_in_hidden":      *Cfg.EmailSettings.UsernameSignInHidden,
 		"require_email_verification":   Cfg.EmailSettings.RequireEmailVerification,
 		"send_email_notifications":     Cfg.EmailSettings.SendEmailNotifications,
 		"connection_security":          Cfg.EmailSettings.ConnectionSecurity,

--- a/webapp/components/admin_console/email_authentication_settings.jsx
+++ b/webapp/components/admin_console/email_authentication_settings.jsx
@@ -21,6 +21,8 @@ export default class EmailAuthenticationSettings extends AdminSettings {
         config.EmailSettings.EnableSignUpWithEmail = this.state.enableSignUpWithEmail;
         config.EmailSettings.EnableSignInWithEmail = this.state.enableSignInWithEmail;
         config.EmailSettings.EnableSignInWithUsername = this.state.enableSignInWithUsername;
+        config.EmailSettings.EmailSignInHidden = this.state.emailSigninHidden;
+        config.EmailSettings.UsernameSignInHidden = this.state.usernameSigninHidden;
 
         return config;
     }
@@ -29,7 +31,9 @@ export default class EmailAuthenticationSettings extends AdminSettings {
         return {
             enableSignUpWithEmail: config.EmailSettings.EnableSignUpWithEmail,
             enableSignInWithEmail: config.EmailSettings.EnableSignInWithEmail,
-            enableSignInWithUsername: config.EmailSettings.EnableSignInWithUsername
+            enableSignInWithUsername: config.EmailSettings.EnableSignInWithUsername,
+            emailSigninHidden: config.EmailSettings.EmailSignInHidden,
+            usernameSigninHidden: config.EmailSettings.UsernameSignInHidden
         };
     }
 
@@ -96,6 +100,28 @@ export default class EmailAuthenticationSettings extends AdminSettings {
                         />
                     }
                     value={this.state.enableSignInWithUsername}
+                    onChange={this.handleChange}
+                />
+                <BooleanSetting
+                    id='emailSigninHidden'
+                    label={
+                        <FormattedMessage
+                            id='admin.email.hideEmailSignInTitle'
+                            defaultMessage='Hide sign-in with email: '
+                        />
+                    }
+                    value={this.state.emailSigninHidden}
+                    onChange={this.handleChange}
+                />
+                <BooleanSetting
+                    id='usernameSigninHidden'
+                    label={
+                        <FormattedMessage
+                            id='admin.email.hideUsernameSignInTitle'
+                            defaultMessage='Hide sign-in with username: '
+                        />
+                    }
+                    value={this.state.usernameSigninHidden}
                     onChange={this.handleChange}
                 />
             </SettingsGroup>

--- a/webapp/components/login/login_controller.jsx
+++ b/webapp/components/login/login_controller.jsx
@@ -43,8 +43,8 @@ export default class LoginController extends React.Component {
 
         this.state = {
             ldapEnabled: global.window.mm_license.IsLicensed === 'true' && global.window.mm_config.EnableLdap === 'true',
-            usernameSigninEnabled: global.window.mm_config.EnableSignInWithUsername === 'true',
-            emailSigninEnabled: global.window.mm_config.EnableSignInWithEmail === 'true',
+            usernameSigninHidden: global.window.mm_config.UsernameSignInHidden === 'true',
+            emailSigninHidden: global.window.mm_config.EmailSignInHidden === 'true',
             samlEnabled: global.window.mm_license.IsLicensed === 'true' && global.window.mm_config.EnableSaml === 'true',
             loginId: '', // the browser will set a default for this
             password: '',
@@ -87,10 +87,10 @@ export default class LoginController extends React.Component {
         if (!loginId) {
             // it's slightly weird to be constructing the message ID, but it's a bit nicer than triply nested if statements
             let msgId = 'login.no';
-            if (this.state.emailSigninEnabled) {
+            if (!this.state.emailSigninHidden) {
                 msgId += 'Email';
             }
-            if (this.state.usernameSigninEnabled) {
+            if (!this.state.usernameSigninHidden) {
                 msgId += 'Username';
             }
             if (this.state.ldapEnabled) {
@@ -261,15 +261,15 @@ export default class LoginController extends React.Component {
             return 'Login with your email';
         }
         const ldapEnabled = this.state.ldapEnabled;
-        const usernameSigninEnabled = this.state.usernameSigninEnabled;
-        const emailSigninEnabled = this.state.emailSigninEnabled;
+        const usernameSigninHidden = this.state.usernameSigninHidden;
+        const emailSigninHidden = this.state.emailSigninHidden;
 
         const loginPlaceholders = [];
-        if (emailSigninEnabled) {
+        if (!emailSigninHidden) {
             loginPlaceholders.push(Utils.localizeMessage('login.email', 'Email'));
         }
 
-        if (usernameSigninEnabled) {
+        if (!usernameSigninHidden) {
             loginPlaceholders.push(Utils.localizeMessage('login.username', 'Username'));
         }
 
@@ -355,10 +355,10 @@ export default class LoginController extends React.Component {
         const googleSigninEnabled = global.window.mm_config.EnableSignUpWithGoogle === 'true';
         const office365SigninEnabled = global.window.mm_config.EnableSignUpWithOffice365 === 'true';
         const samlSigninEnabled = this.state.samlEnabled;
-        const usernameSigninEnabled = this.state.usernameSigninEnabled;
-        const emailSigninEnabled = this.state.emailSigninEnabled;
+        const usernameSigninHidden = this.state.usernameSigninHidden;
+        const emailSigninHidden = this.state.emailSigninHidden;
 
-        if (emailSigninEnabled || usernameSigninEnabled || ldapEnabled) {
+        if (!emailSigninHidden || !usernameSigninHidden || ldapEnabled) {
             let errorClass = '';
             if (this.state.serverError) {
                 errorClass = ' has-error';
@@ -453,7 +453,7 @@ export default class LoginController extends React.Component {
             );
         }
 
-        if (usernameSigninEnabled || emailSigninEnabled) {
+        if (!usernameSigninHidden || !emailSigninHidden) {
             loginControls.push(
                 <div
                     key='forgotPassword'
@@ -472,7 +472,7 @@ export default class LoginController extends React.Component {
             );
         }
 
-        if ((emailSigninEnabled || usernameSigninEnabled || ldapEnabled) && (gitlabSigninEnabled || googleSigninEnabled || samlSigninEnabled || office365SigninEnabled)) {
+        if ((!emailSigninHidden || !usernameSigninHidden || ldapEnabled) && (gitlabSigninEnabled || googleSigninEnabled || office365SigninEnabled)) {
             loginControls.push(
                 <div
                     key='divider'
@@ -495,7 +495,7 @@ export default class LoginController extends React.Component {
             );
         }
 
-        if (gitlabSigninEnabled || samlSigninEnabled || office365SigninEnabled || googleSigninEnabled || gitlabSigninEnabled) {
+        if (gitlabSigninEnabled || office365SigninEnabled || googleSigninEnabled || gitlabSigninEnabled) {
             loginControls.push(
                 <h5 key='oauthHeader'>
                     <FormattedMessage
@@ -561,9 +561,13 @@ export default class LoginController extends React.Component {
         }
 
         if (samlSigninEnabled) {
+            let samlClassname = 'btn btn-custom-login saml';
+            if (emailSigninHidden && usernameSigninHidden) {
+                samlClassname += ' email-username-hidden';
+            }
             loginControls.push(
                 <a
-                    className='btn btn-custom-login saml'
+                    className={samlClassname}
                     key='saml'
                     href={'/login/sso/saml' + this.props.location.search}
                 >

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -233,6 +233,8 @@
   "admin.email.allowSignupTitle": "Enable account creation with email: ",
   "admin.email.allowUsernameSignInDescription": "When true, uChat allows users to sign in using their username and password.  This setting is typically only used when email verification is disabled.",
   "admin.email.allowUsernameSignInTitle": "Enable sign-in with username: ",
+  "admin.email.hideEmailSignInTitle": "Hide sign-in with email: ",
+  "admin.email.hideUsernameSignInTitle": "Hide sign-in with username: ",
   "admin.email.connectionSecurityTest": "Test Connection",
   "admin.email.easHelp": "Learn more about compiling and deploying your own mobile apps from an <a href=\"http://docs.mattermost.com/deployment/push.html#enterprise-app-store-eas\" target=\"_blank\">Enterprise App Store</a>.",
   "admin.email.emailFail": "Connection unsuccessful: {error}",

--- a/webapp/sass/routes/_signup.scss
+++ b/webapp/sass/routes/_signup.scss
@@ -317,6 +317,12 @@
                 span {
                     vertical-align: middle;
                 }
+
+                &.email-username-hidden {
+                    margin: 0 auto;
+                    padding: 0;
+                    text-align: center;
+                }
             }
 
             &.btn--full {


### PR DESCRIPTION
- Add two config options: `EmailSignInHidden` and `UsernameSignInHidden`
- Change styling when both email and username signin are hidden
- Add corresponding setting toggle in system console
- Briefly tested locally by manually overriding settings inside client code
<img width="324" alt="screen shot 2016-12-27 at 12 36 54 pm" src="https://cloud.githubusercontent.com/assets/910657/21508655/a7621afe-cc37-11e6-95d3-6d2576fe9723.png">

![demo](https://cloud.githubusercontent.com/assets/910657/21508656/a762168a-cc37-11e6-9edc-cc31c98dfd5f.gif)
