### PR TITLE
SSO Disable Transfer

### DIFF
--- a/api/user.go
+++ b/api/user.go
@@ -1990,6 +1990,12 @@ func IsUsernameTaken(name string) bool {
 func emailToOAuth(c *Context, w http.ResponseWriter, r *http.Request) {
 	props := model.MapFromJson(r.Body)
 
+	if !*utils.Cfg.ServiceSettings.EnableAuthenticationTransfer {
+		c.Err = model.NewLocAppError("emailToOAuth", "api.user.email_to_oauth.not_available.app_error", nil, "")
+		c.Err.StatusCode = http.StatusForbidden
+		return
+	}
+
 	password := props["password"]
 	if len(password) == 0 {
 		c.SetInvalidParam("emailToOAuth", "password")
@@ -2049,6 +2055,12 @@ func emailToOAuth(c *Context, w http.ResponseWriter, r *http.Request) {
 func oauthToEmail(c *Context, w http.ResponseWriter, r *http.Request) {
 	props := model.MapFromJson(r.Body)
 
+	if !*utils.Cfg.ServiceSettings.EnableAuthenticationTransfer {
+		c.Err = model.NewLocAppError("oauthToEmail", "api.user.oauth_to_email.not_available.app_error", nil, "")
+		c.Err.StatusCode = http.StatusForbidden
+		return
+	}
+
 	password := props["password"]
 	if err := utils.IsPasswordValid(password); err != nil {
 		c.Err = err
@@ -2102,6 +2114,12 @@ func oauthToEmail(c *Context, w http.ResponseWriter, r *http.Request) {
 
 func emailToLdap(c *Context, w http.ResponseWriter, r *http.Request) {
 	props := model.MapFromJson(r.Body)
+
+	if !*utils.Cfg.ServiceSettings.EnableAuthenticationTransfer {
+		c.Err = model.NewLocAppError("emailToLdap", "api.user.email_to_ldap.not_available.app_error", nil, "")
+		c.Err.StatusCode = http.StatusForbidden
+		return
+	}
 
 	email := props["email"]
 	if len(email) == 0 {
@@ -2174,6 +2192,12 @@ func emailToLdap(c *Context, w http.ResponseWriter, r *http.Request) {
 
 func ldapToEmail(c *Context, w http.ResponseWriter, r *http.Request) {
 	props := model.MapFromJson(r.Body)
+
+	if !*utils.Cfg.ServiceSettings.EnableAuthenticationTransfer {
+		c.Err = model.NewLocAppError("ldapToEmail", "api.user.ldap_to_email.not_available.app_error", nil, "")
+		c.Err.StatusCode = http.StatusForbidden
+		return
+	}
 
 	email := props["email"]
 	if len(email) == 0 {

--- a/config/config.json
+++ b/config/config.json
@@ -34,7 +34,8 @@
         "WebsocketPort": 80,
         "WebserverMode": "gzip",
         "EnableCustomEmoji": false,
-        "RestrictCustomEmojiCreation": "all"
+        "RestrictCustomEmojiCreation": "all",
+        "EnableAuthenticationTransfer": true 
     },
     "TeamSettings": {
         "SiteName": "uChat",

--- a/model/config.go
+++ b/model/config.go
@@ -90,6 +90,7 @@ type ServiceSettings struct {
 	WebserverMode                     *string
 	EnableCustomEmoji                 *bool
 	RestrictCustomEmojiCreation       *string
+	EnableAuthenticationTransfer      *bool
 }
 
 type ClusterSettings struct {
@@ -799,6 +800,11 @@ func (o *Config) SetDefaults() {
 	if o.ServiceSettings.RestrictCustomEmojiCreation == nil {
 		o.ServiceSettings.RestrictCustomEmojiCreation = new(string)
 		*o.ServiceSettings.RestrictCustomEmojiCreation = RESTRICT_EMOJI_CREATION_ALL
+	}
+
+	if o.ServiceSettings.EnableAuthenticationTransfer == nil {
+		o.ServiceSettings.EnableAuthenticationTransfer = new(bool)
+		*o.ServiceSettings.EnableAuthenticationTransfer = true
 	}
 
 	if o.ClusterSettings.InterNodeListenAddress == nil {

--- a/utils/config.go
+++ b/utils/config.go
@@ -295,6 +295,7 @@ func getClientConfig(c *model.Config) map[string]string {
 
 	props["EnableCustomEmoji"] = strconv.FormatBool(*c.ServiceSettings.EnableCustomEmoji)
 	props["RestrictCustomEmojiCreation"] = *c.ServiceSettings.RestrictCustomEmojiCreation
+	props["EnableAuthenticationTransfer"] = strconv.FormatBool(*c.ServiceSettings.EnableAuthenticationTransfer)
 	props["MaxFileSize"] = strconv.FormatInt(*c.FileSettings.MaxFileSize, 10)
 
 	props["AppDownloadLink"] = *c.NativeAppSettings.AppDownloadLink

--- a/utils/diagnostic.go
+++ b/utils/diagnostic.go
@@ -79,6 +79,7 @@ func trackConfig() {
 		"enable_post_username_override":        Cfg.ServiceSettings.EnablePostUsernameOverride,
 		"enable_post_icon_override":            Cfg.ServiceSettings.EnablePostIconOverride,
 		"enable_custom_emoji":                  *Cfg.ServiceSettings.EnableCustomEmoji,
+		"enable_authentication_transfer":       *Cfg.ServiceSettings.EnableAuthenticationTransfer,
 		"restrict_custom_emoji_creation":       *Cfg.ServiceSettings.RestrictCustomEmojiCreation,
 		"enable_testing":                       Cfg.ServiceSettings.EnableTesting,
 		"enable_developer":                     *Cfg.ServiceSettings.EnableDeveloper,

--- a/webapp/components/admin_console/admin_team_members_dropdown.jsx
+++ b/webapp/components/admin_console/admin_team_members_dropdown.jsx
@@ -413,20 +413,22 @@ export default class AdminTeamMembersDropdown extends React.Component {
 
         let passwordReset;
         if (user.auth_service) {
-            passwordReset = (
-                <li role='presentation'>
-                    <a
-                        role='menuitem'
-                        href='#'
-                        onClick={this.handleResetPassword}
-                    >
-                        <FormattedMessage
-                            id='admin.user_item.switchToEmail'
-                            defaultMessage='Switch to Email/Password'
-                        />
-                    </a>
-                </li>
-            );
+            if (global.window.mm_config.EnableAuthenticationTransfer === 'true') {
+                passwordReset = (
+                    <li role='presentation'>
+                        <a
+                            role='menuitem'
+                            href='#'
+                            onClick={this.handleResetPassword}
+                        >
+                            <FormattedMessage
+                                id='admin.user_item.switchToEmail'
+                                defaultMessage='Switch to Email/Password'
+                            />
+                        </a>
+                    </li>
+                );
+            }
         } else {
             passwordReset = (
                 <li role='presentation'>


### PR DESCRIPTION
Created to config that would disable authentication transfer methods, ex: ldap to email/password. 

Screenshots of various postman outputs

methods remain enabled:
<img width="952" alt="reenabled" src="https://cloud.githubusercontent.com/assets/9515253/21509683/33a448ae-cc40-11e6-9554-b73b0b4c4f02.png">

invalid token:
<img width="950" alt="invalid token" src="https://cloud.githubusercontent.com/assets/9515253/21509684/33a4b618-cc40-11e6-92c2-734024df539d.png">

Email to ldap:
<img width="963" alt="email_to_ldap" src="https://cloud.githubusercontent.com/assets/9515253/21509686/33a580ac-cc40-11e6-8b11-d156aa5b8813.png">

oauth to email:
<img width="948" alt="oauth_to_email" src="https://cloud.githubusercontent.com/assets/9515253/21509685/33a51d88-cc40-11e6-9c96-4643654195fe.png">

email to oauth:
<img width="949" alt="email_to_oauth" src="https://cloud.githubusercontent.com/assets/9515253/21509688/33a6c0f2-cc40-11e6-89e0-9cd5718f36c8.png">

ldap to email:
<img width="950" alt="ldap_to_email" src="https://cloud.githubusercontent.com/assets/9515253/21509687/33a5b176-cc40-11e6-9011-30e007ae0008.png">
