### PR TITLE
prevent calling hide on undefined

### DIFF
--- a/webapp/components/profile_popover.jsx
+++ b/webapp/components/profile_popover.jsx
@@ -42,7 +42,9 @@ export default class ProfilePopover extends React.Component {
             (channel) => {
                 this.exitToDirectChannel = TeamStore.getCurrentTeamRelativeUrl() + '/channels/' + channel.name;
                 this.setState({loadingDMChannel: false});
-                this.props.parent.refs.overlay.hide();
+                if (this.props.parent && this.props.parent.refs.overlay) {
+                    this.props.parent.refs.overlay.hide();
+                }
                 if (this.exitToDirectChannel) {
                     browserHistory.push(this.exitToDirectChannel);
                 }


### PR DESCRIPTION
If you click the profile popover in staging right now, you will see a javascript error because the overlay is undefined. Not sure if the overlay needs to be dismissed, so just put a if clause just in case.