### PR TITLE
UCHAT-516 fix switch button in channel switcher

### DIFF
--- a/webapp/components/channel_switch_modal.jsx
+++ b/webapp/components/channel_switch_modal.jsx
@@ -82,11 +82,11 @@ export default class SwitchChannelModal extends React.Component {
         this.setState(newState);
 
         if (e.keyCode === Constants.KeyCodes.ENTER) {
-            this.handleSubmit(selectionText);
+            this.handleSubmit(null, selectionText);
         }
     }
 
-    handleSubmit(selectionText) {
+    handleSubmit(e, selectionText) {
         const name = selectionText || this.state.text.trim();
         let channel = null;
 


### PR DESCRIPTION
In the channel switcher, the "Switch" button does not work right now. This is because in one of my previous changes, I modified the signature of `handleSubmit` function to take in a `selectionText` argument. 

However, `handleSubmit` is also being used as an event handler for the "Switch" button. 
Consequently, the assignment: `const name = selectionText || this.state.text.trim();` would assign `name` as the `submit` event instead.

This PR addresses this issue by changing the `handleSubmit` function to include the previously omitted argument.
